### PR TITLE
fix: call backend revokeCurrentSession before Kratos logout

### DIFF
--- a/__tests__/session-revocation.test.tsx
+++ b/__tests__/session-revocation.test.tsx
@@ -649,6 +649,64 @@ describe('useRawLogout - session revocation on logout', () => {
     });
   });
 
+  it('captures Sentry with reason: timeout when mutation exceeds 2s and still completes logout', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const ory = (await import('$lib/utils/ory')).ory as any;
+
+    const mockLocalStorageClear = vi.fn();
+    vi.stubGlobal('localStorage', {
+      clear: mockLocalStorageClear,
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+
+    // Mutation returns a never-resolving promise so the 2s timeout branch wins.
+    mockMutate.mockImplementation(() => new Promise(() => {}));
+
+    ory.createBrowserLogoutFlow.mockClear();
+    ory.updateLogoutFlow.mockClear();
+    ory.createBrowserLogoutFlow.mockResolvedValue({
+      data: { logout_token: 'test-token' },
+    });
+    ory.updateLogoutFlow.mockResolvedValue(undefined);
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await mountLogout(vi.fn());
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('logout-btn'));
+      });
+
+      // Advance past the 2s REVOKE_TIMEOUT_MS and flush pending microtasks.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      vi.useRealTimers();
+
+      await waitFor(() => {
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({
+            tags: expect.objectContaining({
+              flow: 'logout',
+              reason: 'timeout',
+            }),
+          }),
+        );
+        // Logout still completes despite the timeout.
+        expect(ory.updateLogoutFlow).toHaveBeenCalled();
+        expect(mockLocalStorageClear).toHaveBeenCalled();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does NOT block logout when mutation fails — Kratos logout + storage clear still run', async () => {
     const mockLocalStorageClear = vi.fn();
     const mockSessionStorageClear = vi.fn();

--- a/__tests__/session-revocation.test.tsx
+++ b/__tests__/session-revocation.test.tsx
@@ -499,3 +499,198 @@ describe('useLogout WS dispose', () => {
     });
   });
 });
+
+// ============================================================
+// Test Suite 5: useRawLogout - session revocation on logout
+// ============================================================
+describe('useRawLogout - session revocation on logout', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockMutate.mockReset();
+    mockMutate.mockResolvedValue({ data: null, error: null });
+    (globalThis as any).__mockMutate = mockMutate;
+
+    // Reset localStorage/sessionStorage stubs
+    vi.stubGlobal('localStorage', {
+      clear: vi.fn(),
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+    vi.stubGlobal('sessionStorage', {
+      clear: vi.fn(),
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+  });
+
+  async function mountLogout(disposeImpl: () => void) {
+    const { GraphQLWSContext } = await import('$lib/graphql/subscription/context');
+    const { useRawLogout } = await import('$lib/hooks/useLogout');
+
+    function TestComponent() {
+      const rawLogout = useRawLogout();
+      return (
+        <button data-testid="logout-btn" onClick={() => rawLogout()}>
+          Logout
+        </button>
+      );
+    }
+
+    await act(async () => {
+      render(
+        <GraphQLWSContext.Provider value={{ client: null, dispose: disposeImpl }}>
+          <TestComponent />
+        </GraphQLWSContext.Provider>,
+      );
+    });
+  }
+
+  it('calls revokeCurrentSession mutation BEFORE Kratos logout flow', async () => {
+    const callOrder: string[] = [];
+    mockMutate.mockImplementation(async () => {
+      callOrder.push('revokeCurrentSession');
+      return { data: null, error: null };
+    });
+
+    const ory = (await import('$lib/utils/ory')).ory as any;
+    ory.createBrowserLogoutFlow.mockImplementation(async () => {
+      callOrder.push('createBrowserLogoutFlow');
+      return { data: { logout_token: 'test-token' } };
+    });
+    ory.updateLogoutFlow.mockImplementation(async () => {
+      callOrder.push('updateLogoutFlow');
+    });
+
+    await mountLogout(vi.fn());
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('logout-btn'));
+    });
+
+    await waitFor(() => {
+      expect(callOrder).toContain('revokeCurrentSession');
+      expect(callOrder).toContain('createBrowserLogoutFlow');
+    });
+
+    expect(callOrder.indexOf('revokeCurrentSession')).toBeLessThan(
+      callOrder.indexOf('createBrowserLogoutFlow'),
+    );
+    expect(callOrder.indexOf('createBrowserLogoutFlow')).toBeLessThan(
+      callOrder.indexOf('updateLogoutFlow'),
+    );
+  });
+
+  it('calls dispose() BEFORE setSession(null) / localStorage.clear() (invariant preserved)', async () => {
+    const callOrder: string[] = [];
+    const mockDisposeCtx = vi.fn(() => callOrder.push('dispose'));
+    const mockLocalStorageClear = vi.fn(() => callOrder.push('localStorage.clear'));
+
+    vi.stubGlobal('localStorage', {
+      clear: mockLocalStorageClear,
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+
+    mockMutate.mockImplementation(async () => {
+      callOrder.push('revokeCurrentSession');
+      return { data: null, error: null };
+    });
+
+    await mountLogout(mockDisposeCtx);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('logout-btn'));
+    });
+
+    await waitFor(() => {
+      expect(mockDisposeCtx).toHaveBeenCalled();
+      expect(mockLocalStorageClear).toHaveBeenCalled();
+    });
+
+    const disposeIdx = callOrder.indexOf('dispose');
+    const clearIdx = callOrder.indexOf('localStorage.clear');
+    expect(disposeIdx).toBeGreaterThanOrEqual(0);
+    expect(clearIdx).toBeGreaterThanOrEqual(0);
+    expect(disposeIdx).toBeLessThan(clearIdx);
+  });
+
+  it('captures exception to Sentry with flow: logout tag when mutation returns { error }', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const revokeError = new Error('network failure');
+    mockMutate.mockResolvedValue({ data: null, error: revokeError });
+
+    await mountLogout(vi.fn());
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('logout-btn'));
+    });
+
+    await waitFor(() => {
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        revokeError,
+        expect.objectContaining({
+          tags: expect.objectContaining({ flow: 'logout' }),
+        }),
+      );
+    });
+  });
+
+  it('does NOT block logout when mutation fails — Kratos logout + storage clear still run', async () => {
+    const mockLocalStorageClear = vi.fn();
+    const mockSessionStorageClear = vi.fn();
+    vi.stubGlobal('localStorage', {
+      clear: mockLocalStorageClear,
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+    vi.stubGlobal('sessionStorage', {
+      clear: mockSessionStorageClear,
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+
+    mockMutate.mockResolvedValue({
+      data: null,
+      error: new Error('revoke failed'),
+    });
+
+    const ory = (await import('$lib/utils/ory')).ory as any;
+    ory.createBrowserLogoutFlow.mockClear();
+    ory.updateLogoutFlow.mockClear();
+
+    const mockDisposeCtx = vi.fn();
+    await mountLogout(mockDisposeCtx);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('logout-btn'));
+    });
+
+    await waitFor(() => {
+      expect(ory.createBrowserLogoutFlow).toHaveBeenCalled();
+      expect(ory.updateLogoutFlow).toHaveBeenCalled();
+      expect(mockDisposeCtx).toHaveBeenCalled();
+      expect(mockLocalStorageClear).toHaveBeenCalled();
+      expect(mockSessionStorageClear).toHaveBeenCalled();
+    });
+  });
+});

--- a/lib/graphql/gql/backend/session.gql
+++ b/lib/graphql/gql/backend/session.gql
@@ -25,6 +25,10 @@ mutation revokeMySession($sessionId: MongoID!) {
   }
 }
 
+mutation revokeCurrentSession {
+  revokeCurrentSession
+}
+
 mutation requestStepUpVerification {
   requestStepUpVerification {
     success

--- a/lib/hooks/useLogout.ts
+++ b/lib/hooks/useLogout.ts
@@ -15,6 +15,8 @@ const RevokeCurrentSessionDocument = `
   }
 ` as unknown as TypedDocumentNode<{ revokeCurrentSession: boolean }, Record<string, never>>;
 
+const REVOKE_TIMEOUT_MS = 2000;
+
 export function useRawLogout() {
   const setSession = useSetAtom(sessionAtom);
   const hydraClientId = useAtomValue(hydraClientIdAtom);
@@ -25,10 +27,29 @@ export function useRawLogout() {
     // Notify backend to close any live WS connections for this session. Must run
     // BEFORE Kratos logout so the auth cookie is still valid when the request
     // reaches the backend. Failure is non-blocking — the periodic revalidator
-    // catches stale sockets within 5 minutes.
-    const { error: revokeError } = await revokeCurrentSession({});
+    // catches stale sockets within 5 minutes. A 2s timeout prevents a backend
+    // hang from blocking logout UX indefinitely.
+    const revokeWithTimeout = Promise.race([
+      revokeCurrentSession({}),
+      new Promise<{ error: Error }>((resolve) =>
+        setTimeout(
+          () =>
+            resolve({ error: new Error('revokeCurrentSession timeout') }),
+          REVOKE_TIMEOUT_MS,
+        ),
+      ),
+    ]);
+    const { error: revokeError } = await revokeWithTimeout;
     if (revokeError) {
-      Sentry.captureException(revokeError, { tags: { flow: 'logout' } });
+      const isTimeout =
+        revokeError instanceof Error &&
+        revokeError.message === 'revokeCurrentSession timeout';
+      Sentry.captureException(revokeError, {
+        tags: {
+          flow: 'logout',
+          ...(isTimeout ? { reason: 'timeout' } : {}),
+        },
+      });
     }
 
     // Dispose WebSocket connection BEFORE clearing local state

--- a/lib/hooks/useLogout.ts
+++ b/lib/hooks/useLogout.ts
@@ -29,6 +29,9 @@ export function useRawLogout() {
     // reaches the backend. Failure is non-blocking — the periodic revalidator
     // catches stale sockets within 5 minutes. A 2s timeout prevents a backend
     // hang from blocking logout UX indefinitely.
+    // Promise.race leaks the losing revokeCurrentSession promise on timeout —
+    // acceptable since logout is terminal (page navigates); AbortController
+    // plumbing through useMutation is out of scope for this fix.
     const revokeWithTimeout = Promise.race([
       revokeCurrentSession({}),
       new Promise<{ error: Error }>((resolve) =>

--- a/lib/hooks/useLogout.ts
+++ b/lib/hooks/useLogout.ts
@@ -2,17 +2,35 @@
 import { useContext } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import * as Sentry from '@sentry/nextjs';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { ory } from '$lib/utils/ory';
 import { hydraClientIdAtom, sessionAtom } from '$lib/jotai';
 import { GraphQLWSContext } from '$lib/graphql/subscription/context';
+import { useMutation } from '$lib/graphql/request';
+
+const RevokeCurrentSessionDocument = `
+  mutation revokeCurrentSession {
+    revokeCurrentSession
+  }
+` as unknown as TypedDocumentNode<{ revokeCurrentSession: boolean }, Record<string, never>>;
 
 export function useRawLogout() {
   const setSession = useSetAtom(sessionAtom);
   const hydraClientId = useAtomValue(hydraClientIdAtom);
   const { dispose } = useContext(GraphQLWSContext);
+  const [revokeCurrentSession] = useMutation(RevokeCurrentSessionDocument);
 
   return async () => {
+    // Notify backend to close any live WS connections for this session. Must run
+    // BEFORE Kratos logout so the auth cookie is still valid when the request
+    // reaches the backend. Failure is non-blocking — the periodic revalidator
+    // catches stale sockets within 5 minutes.
+    const { error: revokeError } = await revokeCurrentSession({});
+    if (revokeError) {
+      Sentry.captureException(revokeError, { tags: { flow: 'logout' } });
+    }
+
     // Dispose WebSocket connection BEFORE clearing local state
     // to prevent close-code handlers from racing with cleanup.
     dispose();


### PR DESCRIPTION
## Summary

The WebSocket session revocation feature (PR #1136) relied on a Kratos \`logout.after\` webhook that Kratos does not support in any version (see lemonade-cdk and lemonade-backend companion PRs).

Replace that trigger with an explicit, authenticated FE→BE call from the logout hook.

## Changes

**\`lib/hooks/useLogout.ts\`** — \`useRawLogout\` now runs in this order:

1. \`revokeCurrentSession\` mutation — while the auth cookie is still valid, so the backend can resolve identity + session from \`ctx.state.auth\` and publish \`SESSION_REVOKED\`
2. \`dispose()\` the GraphQL WS client — prevents the 4401 close-code handler from racing with cleanup
3. Kratos \`createBrowserLogoutFlow\` + \`updateLogoutFlow\` — clears Kratos session cookie
4. Clear Sentry user, \`sessionAtom\`, localStorage, sessionStorage

Backend-call failure is **non-blocking** — Sentry captures the exception with \`tags: { flow: 'logout' }\` and the logout proceeds. The backend's 5-minute periodic token revalidator closes any sockets the FE-initiated revocation missed.

**\`lib/graphql/gql/backend/session.gql\`** — add \`revokeCurrentSession\` mutation declaration (matches backend companion PR's resolver).

Inline \`RevokeCurrentSessionDocument\` string follows the same pattern as \`settings/security/sessions/page.tsx\` (to avoid shipping the graphql parser to the client bundle).

## Coordination

Part of a 3-repo fix. Merges **together** with:
- lemonade-cdk: \`fix/kratos-logout-remove-invalid-hooks\` (#342)
- lemonade-backend: \`fix/session-revocation-auth-gated-logout\` (#2081)

## Test plan
- [ ] \`yarn tsc --noEmit\` — clean (verified)
- [ ] \`yarn lint\` — no new errors (verified)
- [ ] \`__tests__/session-revocation.test.tsx\` — 9/9 passing (verified)
- [ ] After BE PR deploys to staging: log out from device A → active WS on device A closes; active session row is deleted; another logged-in tab on same session gets 4401
- [ ] Backend mutation failure: simulate 500 → logout still completes, Sentry captures with \`flow: logout\` tag
- [ ] Kratos logout still works for OIDC-flow path (\`hydraClientId\` present) — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)