### PR TITLE
refactor: move community verification to a side pane

### DIFF
--- a/app/[domain]/(blank)/s/manage/[uid]/(standalone)/verify/page.tsx
+++ b/app/[domain]/(blank)/s/manage/[uid]/(standalone)/verify/page.tsx
@@ -1,5 +1,0 @@
-import { VerifyCommunityPage } from '$lib/components/features/community-manage/VerifyCommunityPage';
-
-export default function Page({ params }: { params: { uid: string } }) {
-  return <VerifyCommunityPage uid={params.uid} />;
-}

--- a/lib/components/core/button/button.tsx
+++ b/lib/components/core/button/button.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { HTMLAttributes } from 'react';
+import React from 'react';
 import { twMerge } from 'tailwind-merge';
 
 const sizes: { [key: string]: string } = {
@@ -30,7 +30,7 @@ const iconSizeBase = {
   xs: 'size-4',
 };
 
-interface ButtonProps extends React.PropsWithChildren<HTMLAttributes<HTMLButtonElement>> {
+interface ButtonProps extends React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>> {
   size?: 'sm' | 'base' | 'lg' | 'xs';
   variant?: 'primary' | 'success' | 'danger' | 'tertiary' | 'tertiary-alt' | 'secondary' | 'flat' | 'warning';
   icon?: string;

--- a/lib/components/features/community-manage/CommunityNewsletter.tsx
+++ b/lib/components/features/community-manage/CommunityNewsletter.tsx
@@ -23,7 +23,7 @@ import { useMutation, useQuery } from '$lib/graphql/request';
 import { useConfirmation } from '$lib/hooks/useConfirmation';
 import { RECIPIENT_TYPE_MAP } from '$lib/utils/email';
 import { htmlToInlineText } from '$lib/utils/string';
-import { isToday } from 'date-fns';
+import { format, isToday } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 import { useCommunityManageSpace } from './CommunityManageSpaceContext';
@@ -62,7 +62,7 @@ export function CommunityNewsletter({ spaceIdOrSlug }: CommunityNewsletterProps)
     },
   });
 
-  const { data: verificationData, loading: loadingVerification } = useQuery(GetSpaceVerificationSubmissionDocument, {
+  const { data: verificationData, loading: loadingVerification, refetch: refetchVerification } = useQuery(GetSpaceVerificationSubmissionDocument, {
     variables: { space: ctx?.space._id || '' },
     skip: !ctx?.space._id,
     fetchPolicy: 'cache-and-network',
@@ -243,7 +243,14 @@ export function CommunityNewsletter({ spaceIdOrSlug }: CommunityNewsletterProps)
                 outlined
                 iconRight="icon-chevron-right"
                 className="w-fit"
-                onClick={() => drawer.open(VerifyCommunityPane, { props: { uid: spaceIdOrSlug } })}
+                onClick={() =>
+                  drawer.open(VerifyCommunityPane, {
+                    props: {
+                      space: ctx!.space,
+                      onCompleted: refetchVerification,
+                    },
+                  })
+                }
               >
                 Verify
               </Button>

--- a/lib/components/features/community-manage/CommunityNewsletter.tsx
+++ b/lib/components/features/community-manage/CommunityNewsletter.tsx
@@ -23,11 +23,13 @@ import { useMutation, useQuery } from '$lib/graphql/request';
 import { useConfirmation } from '$lib/hooks/useConfirmation';
 import { RECIPIENT_TYPE_MAP } from '$lib/utils/email';
 import { htmlToInlineText } from '$lib/utils/string';
-import { format, isToday } from 'date-fns';
+import { isToday } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 import { useCommunityManageSpace } from './CommunityManageSpaceContext';
 import { NewsletterStatsPane } from './panes/NewsletterStatsPane';
+import { VerifyCommunityPane } from './VerifyCommunityPane';
+import { VerificationSubmissionStatusCard } from './VerificationSubmissionStatusCard';
 
 interface CommunityNewsletterProps {
   spaceIdOrSlug: string;
@@ -66,8 +68,13 @@ export function CommunityNewsletter({ spaceIdOrSlug }: CommunityNewsletterProps)
     fetchPolicy: 'cache-and-network',
   });
 
+  const verificationSubmission = verificationData?.getSpaceVerificationSubmission || null;
   const isLoadingVerification = loadingVerification && !verificationData;
-  const isVerified = verificationData?.getSpaceVerificationSubmission?.state === SpaceVerificationState.Approved;
+  const isVerified = verificationSubmission?.state === SpaceVerificationState.Approved;
+  const isVerificationPending =
+    !!verificationSubmission &&
+    verificationSubmission.state !== SpaceVerificationState.Approved &&
+    verificationSubmission.state !== SpaceVerificationState.Rejected;
 
   const {
     data: newslettersData,
@@ -221,6 +228,8 @@ export function CommunityNewsletter({ spaceIdOrSlug }: CommunityNewsletterProps)
               <DraftListSkeleton />
               <Skeleton animate className="h-9 w-26 rounded-sm" />
             </>
+          ) : isVerificationPending ? (
+            <VerificationSubmissionStatusCard submission={verificationSubmission!} />
           ) : !isVerified ? (
             <div className="flex flex-col gap-3 rounded-md border border-card-border bg-warning-300/16 px-4 py-3 backdrop-blur-md sm:flex-row sm:items-center sm:justify-between">
               <div className="space-y-0.5">
@@ -234,7 +243,7 @@ export function CommunityNewsletter({ spaceIdOrSlug }: CommunityNewsletterProps)
                 outlined
                 iconRight="icon-chevron-right"
                 className="w-fit"
-                onClick={() => router.push(`/s/manage/${spaceIdOrSlug}/verify`)}
+                onClick={() => drawer.open(VerifyCommunityPane, { props: { uid: spaceIdOrSlug } })}
               >
                 Verify
               </Button>

--- a/lib/components/features/community-manage/VerificationSubmissionStatusCard.tsx
+++ b/lib/components/features/community-manage/VerificationSubmissionStatusCard.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React from 'react';
+import { format } from 'date-fns';
+
+import { SpaceVerificationState, SpaceVerificationSubmission } from '$lib/graphql/generated/backend/graphql';
+
+function getVerificationStatusInfo(submission: SpaceVerificationSubmission): {
+  icon: string;
+  iconBg: string;
+  title: string;
+  description: string;
+  actionLabel?: string;
+} {
+  if (submission.state === SpaceVerificationState.Approved) {
+    return {
+      icon: 'icon-check text-success-500',
+      iconBg: 'bg-success-500/16',
+      title: 'Verification Request Approved',
+      description: 'Your community has been verified and you can now enjoy higher invite and newsletter limits.',
+    };
+  }
+
+  if (submission.state === SpaceVerificationState.Rejected) {
+    return {
+      icon: 'icon-x text-danger-400',
+      iconBg: 'bg-danger-400/16',
+      title: 'Verification Request Not approved',
+      description: 'We were unable to verify your community. Please make sure you provide accurate information.',
+      actionLabel: 'Submit Another Request',
+    };
+  }
+
+  return {
+    icon: 'icon-email text-tertiary',
+    iconBg: 'bg-(--btn-tertiary)',
+    title: 'Verification Request Received',
+    description: `We received your application on ${format(
+      new Date(submission.updated_at || submission.created_at),
+      'd MMMM',
+    )}. We process most submissions within 30 minutes and all submissions within 12 hours.`,
+  };
+}
+
+export function VerificationSubmissionStatusCard({
+  submission,
+  onRejectedAction,
+}: {
+  submission: SpaceVerificationSubmission;
+  onRejectedAction?: () => void;
+}) {
+  const statusInfo = getVerificationStatusInfo(submission);
+
+  return (
+    <div className="rounded-lg border border-card-border bg-card p-4 flex flex-col gap-4">
+      <div className={`size-14 rounded-full flex items-center justify-center ${statusInfo.iconBg}`}>
+        <i aria-hidden="true" className={`${statusInfo.icon} size-8`} />
+      </div>
+      <div className="space-y-2">
+        <p className="text-lg leading-6">{statusInfo.title}</p>
+        <p className="text-sm text-secondary">{statusInfo.description}</p>
+        {submission.state === SpaceVerificationState.Rejected && statusInfo.actionLabel && onRejectedAction ? (
+          <button
+            type="button"
+            className="text-sm text-accent-400 hover:text-accent-300 transition-colors"
+            onClick={onRejectedAction}
+          >
+            {statusInfo.actionLabel}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/lib/components/features/community-manage/VerifyCommunityPane.tsx
+++ b/lib/components/features/community-manage/VerifyCommunityPane.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 import React from 'react';
-import { format } from 'date-fns';
 
 import {
   CreateSpaceVerificationSubmissionDocument,
@@ -10,56 +9,20 @@ import {
   GetSpaceVerificationSubmissionDocument,
   Space,
   SpaceVerificationState,
-  SpaceVerificationSubmission,
 } from '$lib/graphql/generated/backend/graphql';
 import { useMutation, useQuery } from '$lib/graphql/request';
 import { generateUrl } from '$lib/utils/cnd';
 import { isObjectId } from '$lib/utils/helpers';
 import { Button } from '$lib/components/core/button/button';
+import { drawer } from '$lib/components/core/dialog';
 import { Checkbox } from '$lib/components/core/input/checkbox';
 import { InputField } from '$lib/components/core/input/input-field';
 import { TextAreaField } from '$lib/components/core/input/textarea';
+import { Pane } from '$lib/components/core/pane/pane';
 import { toast } from '$lib/components/core/toast/toast';
-import Header from '$lib/components/layouts/header';
+import { VerificationSubmissionStatusCard } from './VerificationSubmissionStatusCard';
 
-function getVerificationStatusInfo(submission: SpaceVerificationSubmission): {
-  icon: string;
-  iconBg: string;
-  title: string;
-  description: string;
-  actionLabel?: string;
-} {
-  if (submission.state === SpaceVerificationState.Approved) {
-    return {
-      icon: 'icon-check text-success-500',
-      iconBg: 'bg-success-500/16',
-      title: 'Verification Request Approved',
-      description: 'Your community has been verified and you can now enjoy higher invite and newsletter limits.',
-    };
-  }
-
-  if (submission.state === SpaceVerificationState.Rejected) {
-    return {
-      icon: 'icon-x text-danger-400',
-      iconBg: 'bg-danger-400/16',
-      title: 'Verification Request Not approved',
-      description: 'We were unable to verify your community. Please make sure you provide accurate information.',
-      actionLabel: 'Submit Another Request',
-    };
-  }
-
-  return {
-    icon: 'icon-email text-tertiary',
-    iconBg: 'bg-(--btn-tertiary)',
-    title: 'Verification Request Received',
-    description: `We received your application on ${format(
-      new Date(submission.updated_at || submission.created_at),
-      'd MMMM',
-    )}. We process most submissions within 30 minutes and all submissions within 12 hours.`,
-  };
-}
-
-export function VerifyCommunityPage({ uid }: { uid: string }) {
+export function VerifyCommunityPane({ uid }: { uid: string }) {
   const [forceVerify, setForceVerify] = React.useState(false);
 
   const spaceVariables = isObjectId(uid) ? { id: uid, slug: uid } : { slug: uid };
@@ -82,15 +45,35 @@ export function VerifyCommunityPage({ uid }: { uid: string }) {
 
   const verificationSubmission = verificationData?.getSpaceVerificationSubmission || null;
   const showHistory = !!verificationSubmission && !forceVerify;
-  const statusInfo = verificationSubmission ? getVerificationStatusInfo(verificationSubmission) : null;
+  const form = useVerifyCommunityForm({
+    space,
+    enabled: !!space && !loadingVerification && !showHistory,
+    onCompleted: async () => {
+      setForceVerify(false);
+      const result = await refetch();
+      const nextSubmission = result.data?.getSpaceVerificationSubmission;
+
+      if (
+        nextSubmission &&
+        nextSubmission.state !== SpaceVerificationState.Approved &&
+        nextSubmission.state !== SpaceVerificationState.Rejected
+      ) {
+        drawer.close();
+      }
+    },
+  });
 
   return (
-    <main className="h-dvh overflow-auto">
-      <Header />
-      <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
-        <div className="flex flex-col gap-8 pb-20">
+    <Pane.Root>
+      <Pane.Header.Root>
+        <Pane.Header.Left className="flex items-center gap-3">
+          <p className="truncate pt-1 text-base font-medium">Verify Community</p>
+        </Pane.Header.Left>
+      </Pane.Header.Root>
+
+      <Pane.Content className="overflow-auto p-4">
+        <div className="flex flex-col gap-6 pb-6">
           <div className="space-y-1">
-            <h1 className="text-2xl font-semibold font-title">Verify Community</h1>
             <p className="text-tertiary">
               In order to increase your invite and newsletter limits, please share some information about your planned
               events and contacts.
@@ -114,39 +97,46 @@ export function VerifyCommunityPage({ uid }: { uid: string }) {
             </div>
           )}
 
-          {!!space && !loadingVerification && showHistory && !!statusInfo && (
-            <div className="rounded-lg border border-card-border bg-card p-4 flex flex-col gap-4">
-              <div className={`size-14 rounded-full flex items-center justify-center ${statusInfo.iconBg}`}>
-                <i aria-hidden="true" className={`${statusInfo.icon} size-8`} />
-              </div>
-              <div className="space-y-2">
-                <p className="text-lg leading-6">{statusInfo.title}</p>
-                <p className="text-sm text-secondary">{statusInfo.description}</p>
-                {verificationSubmission.state === SpaceVerificationState.Rejected && (
-                  <button
-                    type="button"
-                    className="text-sm text-accent-400 hover:text-accent-300 transition-colors"
-                    onClick={() => setForceVerify(true)}
-                  >
-                    {statusInfo.actionLabel}
-                  </button>
-                )}
-              </div>
-            </div>
+          {!!space && !loadingVerification && showHistory && !!verificationSubmission && (
+            <VerificationSubmissionStatusCard
+              submission={verificationSubmission}
+              onRejectedAction={() => setForceVerify(true)}
+            />
           )}
 
           {!!space && !loadingVerification && !showHistory && (
-            <VerifyCommunityForm
+            <VerifyCommunityFormFields
+              formId={form.formId}
               space={space}
-              onCompleted={async () => {
-                setForceVerify(false);
-                await refetch();
-              }}
+              values={form.values}
+              errors={form.errors}
+              recipientsNumber={form.recipientsNumber}
+              onChangeValue={form.onChangeValue}
+              onToggleValue={form.onToggleValue}
+              onSubmit={form.onSubmit}
             />
           )}
         </div>
-      </div>
-    </main>
+      </Pane.Content>
+
+      {!!space && !loadingVerification && !showHistory && (
+        <Pane.Footer>
+          <div className="border-t border-card-border p-4">
+            <Button
+              form={form.formId}
+              type="submit"
+              variant="secondary"
+              iconLeft="icon-done"
+              className="w-full justify-center"
+              loading={form.loading}
+              disabled={!form.canSubmit || form.loading}
+            >
+              Submit Request
+            </Button>
+          </div>
+        </Pane.Footer>
+      )}
+    </Pane.Root>
   );
 }
 
@@ -160,7 +150,15 @@ type FormValues = {
 
 type FormErrors = Partial<Record<keyof FormValues, string>>;
 
-function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted: () => Promise<void> | void }) {
+function useVerifyCommunityForm({
+  space,
+  enabled,
+  onCompleted,
+}: {
+  space?: Space;
+  enabled: boolean;
+  onCompleted: () => Promise<void> | void;
+}) {
   const [values, setValues] = React.useState<FormValues>({
     number_of_recipients: '',
     event_info: '',
@@ -169,6 +167,7 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
     confirmation_2: false,
   });
   const [errors, setErrors] = React.useState<FormErrors>({});
+  const formId = React.useId();
 
   const [createVerificationSubmission, { loading }] = useMutation(CreateSpaceVerificationSubmissionDocument, {
     onComplete: async () => {
@@ -180,7 +179,6 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
     },
   });
 
-  const completedInfo = !!space.image_avatar_expanded && !!space.description;
   const recipientsNumber = Number(values.number_of_recipients);
   const canSubmit =
     Number.isFinite(recipientsNumber) &&
@@ -220,7 +218,7 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!validate()) {
+    if (!enabled || !space || !validate()) {
       return;
     }
 
@@ -238,8 +236,50 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
     });
   };
 
+  const onChangeValue = React.useCallback((field: keyof FormValues, value: string) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  }, []);
+
+  const onToggleValue = React.useCallback((field: 'confirmation_1' | 'confirmation_2', checked: boolean) => {
+    setValues((prev) => ({ ...prev, [field]: checked }));
+  }, []);
+
+  return {
+    canSubmit,
+    errors,
+    formId,
+    loading,
+    onChangeValue,
+    onSubmit,
+    onToggleValue,
+    recipientsNumber,
+    values,
+  };
+}
+
+function VerifyCommunityFormFields({
+  formId,
+  space,
+  values,
+  errors,
+  recipientsNumber,
+  onChangeValue,
+  onToggleValue,
+  onSubmit,
+}: {
+  formId: string;
+  space: Space;
+  values: FormValues;
+  errors: FormErrors;
+  recipientsNumber: number;
+  onChangeValue: (field: 'number_of_recipients' | 'event_info' | 'guests_info', value: string) => void;
+  onToggleValue: (field: 'confirmation_1' | 'confirmation_2', checked: boolean) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => Promise<void>;
+}) {
+  const completedInfo = !!space.image_avatar_expanded && !!space.description;
+
   return (
-    <form onSubmit={onSubmit} className="max-w-128 w-full flex flex-col gap-6">
+    <form id={formId} onSubmit={onSubmit} className="max-w-128 w-full flex flex-col gap-6">
       <div className="rounded-md border border-card-border bg-card px-4 py-3">
         <div className="flex items-center gap-3">
           <div className="size-9 rounded-sm border border-card-border overflow-hidden shrink-0 bg-(--btn-tertiary) flex items-center justify-center">
@@ -293,7 +333,7 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
           className="max-w-40"
           placeholder="100"
           value={values.number_of_recipients}
-          onChangeText={(value) => setValues((prev) => ({ ...prev, number_of_recipients: value }))}
+          onChangeText={(value) => onChangeValue('number_of_recipients', value)}
           error={!!errors.number_of_recipients}
         />
         {errors.number_of_recipients && <p className="text-sm text-danger-400">{errors.number_of_recipients}</p>}
@@ -319,7 +359,7 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
           className="min-h-24"
           rows={4}
           value={values.event_info}
-          onChangeText={(value) => setValues((prev) => ({ ...prev, event_info: value }))}
+          onChangeText={(value) => onChangeValue('event_info', value)}
         />
         {errors.event_info && <p className="text-sm text-danger-400">{errors.event_info}</p>}
       </label>
@@ -335,7 +375,7 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
           className="min-h-24"
           rows={4}
           value={values.guests_info}
-          onChangeText={(value) => setValues((prev) => ({ ...prev, guests_info: value }))}
+          onChangeText={(value) => onChangeValue('guests_info', value)}
         />
         {errors.guests_info && <p className="text-sm text-danger-400">{errors.guests_info}</p>}
       </label>
@@ -345,7 +385,7 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
           <Checkbox
             id="confirmation_1"
             value={values.confirmation_1}
-            onChange={(event) => setValues((prev) => ({ ...prev, confirmation_1: event.target.checked }))}
+            onChange={(event) => onToggleValue('confirmation_1', event.target.checked)}
           >
             <span>I confirm I will not import or contact people with inactive email addresses or who have unsubscribed.</span>
           </Checkbox>
@@ -356,25 +396,13 @@ function VerifyCommunityForm({ space, onCompleted }: { space: Space; onCompleted
           <Checkbox
             id="confirmation_2"
             value={values.confirmation_2}
-            onChange={(event) => setValues((prev) => ({ ...prev, confirmation_2: event.target.checked }))}
+            onChange={(event) => onToggleValue('confirmation_2', event.target.checked)}
           >
             <span>I confirm that I will only message people who have opted in and consented to receiving emails.</span>
           </Checkbox>
           {errors.confirmation_2 && <p className="text-sm text-danger-400">{errors.confirmation_2}</p>}
         </div>
       </div>
-
-      <Button
-        type="submit"
-        size="sm"
-        variant="secondary"
-        iconLeft="icon-done"
-        className="w-fit"
-        loading={loading}
-        disabled={!canSubmit || loading}
-      >
-        Submit Request
-      </Button>
     </form>
   );
 }

--- a/lib/components/features/community-manage/VerifyCommunityPane.tsx
+++ b/lib/components/features/community-manage/VerifyCommunityPane.tsx
@@ -3,16 +3,9 @@
 import Link from 'next/link';
 import React from 'react';
 
-import {
-  CreateSpaceVerificationSubmissionDocument,
-  GetSpaceDocument,
-  GetSpaceVerificationSubmissionDocument,
-  Space,
-  SpaceVerificationState,
-} from '$lib/graphql/generated/backend/graphql';
-import { useMutation, useQuery } from '$lib/graphql/request';
+import { CreateSpaceVerificationSubmissionDocument, Space } from '$lib/graphql/generated/backend/graphql';
+import { useMutation } from '$lib/graphql/request';
 import { generateUrl } from '$lib/utils/cnd';
-import { isObjectId } from '$lib/utils/helpers';
 import { Button } from '$lib/components/core/button/button';
 import { drawer } from '$lib/components/core/dialog';
 import { Checkbox } from '$lib/components/core/input/checkbox';
@@ -20,48 +13,118 @@ import { InputField } from '$lib/components/core/input/input-field';
 import { TextAreaField } from '$lib/components/core/input/textarea';
 import { Pane } from '$lib/components/core/pane/pane';
 import { toast } from '$lib/components/core/toast/toast';
-import { VerificationSubmissionStatusCard } from './VerificationSubmissionStatusCard';
 
-export function VerifyCommunityPane({ uid }: { uid: string }) {
-  const [forceVerify, setForceVerify] = React.useState(false);
+type VerifyCommunityPaneProps = {
+  space: Space;
+  onCompleted?: () => Promise<void> | void;
+};
 
-  const spaceVariables = isObjectId(uid) ? { id: uid, slug: uid } : { slug: uid };
-  const { data: dataGetSpace, loading: loadingSpace } = useQuery(GetSpaceDocument, {
-    variables: spaceVariables,
-    skip: !uid,
-    fetchPolicy: 'cache-and-network',
+type FormValues = {
+  number_of_recipients: string;
+  event_info: string;
+  guests_info: string;
+  confirmation_1: boolean;
+  confirmation_2: boolean;
+};
+
+type FormErrors = Partial<Record<keyof FormValues, string>>;
+
+export function VerifyCommunityPane({ space, onCompleted }: VerifyCommunityPaneProps) {
+  const [values, setValues] = React.useState<FormValues>({
+    number_of_recipients: '',
+    event_info: '',
+    guests_info: '',
+    confirmation_1: false,
+    confirmation_2: false,
   });
+  const [errors, setErrors] = React.useState<FormErrors>({});
+  const formId = React.useId();
 
-  const space = dataGetSpace?.getSpace as Space | undefined;
+  const clearError = React.useCallback((field: keyof FormValues) => {
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      return { ...prev, [field]: undefined };
+    });
+  }, []);
 
-  const { data: verificationData, loading: loadingVerification, refetch } = useQuery(
-    GetSpaceVerificationSubmissionDocument,
-    {
-      variables: { space: space?._id || '' },
-      skip: !space?._id,
-      fetchPolicy: 'cache-and-network',
+  const updateValue = React.useCallback(
+    (field: 'number_of_recipients' | 'event_info' | 'guests_info', value: string) => {
+      setValues((prev) => ({ ...prev, [field]: value }));
+      clearError(field);
     },
+    [clearError],
   );
 
-  const verificationSubmission = verificationData?.getSpaceVerificationSubmission || null;
-  const showHistory = !!verificationSubmission && !forceVerify;
-  const form = useVerifyCommunityForm({
-    space,
-    enabled: !!space && !loadingVerification && !showHistory,
-    onCompleted: async () => {
-      setForceVerify(false);
-      const result = await refetch();
-      const nextSubmission = result.data?.getSpaceVerificationSubmission;
+  const updateConfirmation = React.useCallback(
+    (field: 'confirmation_1' | 'confirmation_2', checked: boolean) => {
+      setValues((prev) => ({ ...prev, [field]: checked }));
+      clearError(field);
+    },
+    [clearError],
+  );
 
-      if (
-        nextSubmission &&
-        nextSubmission.state !== SpaceVerificationState.Approved &&
-        nextSubmission.state !== SpaceVerificationState.Rejected
-      ) {
-        drawer.close();
-      }
+  const [createVerificationSubmission, { loading }] = useMutation(CreateSpaceVerificationSubmissionDocument, {
+    onComplete: async () => {
+      toast.success('Verification request sent!');
+      drawer.close();
+      await onCompleted?.();
+    },
+    onError: () => {
+      toast.error('Failed to send verification request');
     },
   });
+
+  const recipientsNumber = Number(values.number_of_recipients);
+
+  const validate = () => {
+    const nextErrors: FormErrors = {};
+
+    if (!values.number_of_recipients || Number.isNaN(recipientsNumber) || recipientsNumber <= 0) {
+      nextErrors.number_of_recipients = 'Enter a valid number.';
+    }
+
+    if (!values.event_info.trim()) {
+      nextErrors.event_info = 'Please add a bit more detail.';
+    }
+
+    if (!values.guests_info.trim()) {
+      nextErrors.guests_info = 'Please add a bit more detail.';
+    }
+
+    if (!values.confirmation_1) {
+      nextErrors.confirmation_1 = 'Please confirm to continue.';
+    }
+
+    if (!values.confirmation_2) {
+      nextErrors.confirmation_2 = 'Please confirm to continue.';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!validate()) {
+      return;
+    }
+
+    await createVerificationSubmission({
+      variables: {
+        input: {
+          space: space._id,
+          number_of_recipients: recipientsNumber,
+          event_info: values.event_info.trim(),
+          guests_info: values.guests_info.trim(),
+          confirmation_1: values.confirmation_1,
+          confirmation_2: values.confirmation_2,
+        },
+      },
+    });
+  };
+
+  const completedInfo = !!space.image_avatar_expanded && !!space.description;
 
   return (
     <Pane.Root>
@@ -80,329 +143,156 @@ export function VerifyCommunityPane({ uid }: { uid: string }) {
             </p>
           </div>
 
-          {(loadingSpace || loadingVerification) && (
-            <div className="flex items-center gap-2 text-tertiary">
-              <i aria-hidden="true" className="icon-loader size-5 animate-spin" />
-              <p>Loading verification details...</p>
-            </div>
-          )}
+          <form id={formId} onSubmit={onSubmit} className="max-w-128 w-full flex flex-col gap-6">
+            <div className="rounded-md border border-card-border bg-card px-4 py-3">
+              <div className="flex items-center gap-3">
+                <div className="size-9 rounded-sm border border-card-border overflow-hidden shrink-0 bg-(--btn-tertiary) flex items-center justify-center">
+                  {space.image_avatar_expanded ? (
+                    <img
+                      alt={space.title || 'Space avatar'}
+                      className="size-full object-cover"
+                      src={generateUrl(space.image_avatar_expanded, {
+                        resize: { width: 72, height: 72, fit: 'cover' },
+                      })}
+                    />
+                  ) : (
+                    <i aria-hidden="true" className="icon-user-group-outline size-5 text-tertiary" />
+                  )}
+                </div>
 
-          {!loadingSpace && !space && (
-            <div className="max-w-128 rounded-md border border-card-border bg-card px-4 py-3 flex items-center gap-3">
-              <i aria-hidden="true" className="icon-alert-outline size-9 text-warning-400" />
-              <div className="space-y-0.5">
-                <p>Community Not Found</p>
-                <p className="text-sm text-tertiary">We couldn&apos;t find a community for this verification request.</p>
+                <div className="space-y-0.5 min-w-0">
+                  <p className="text-xs text-tertiary">For Community</p>
+                  <p className="truncate">{space.title}</p>
+                </div>
+              </div>
+
+              {!completedInfo ? (
+                <div className="mt-3 pl-12 space-y-3">
+                  <div className="border-t border-card-border" />
+                  <div className="space-y-2">
+                    <p className="text-sm text-tertiary">
+                      To ensure timely verification, please complete your community information with a profile picture
+                      and description.
+                    </p>
+                    <Link
+                      href={`/s/manage/${space.slug || space._id}/settings`}
+                      className="inline-flex items-center gap-1 text-sm text-accent-400 hover:text-accent-300 transition-colors"
+                    >
+                      <span>Complete Community Info</span>
+                      <i aria-hidden="true" className="icon-arrow-outward size-4.5" />
+                    </Link>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            <label className="flex flex-col gap-3">
+              <div className="space-y-1">
+                <p>How many people would you like to invite or send newsletters to?</p>
+                <p className="text-sm text-tertiary">
+                  Please share an estimate of the number of messages you plan to send at once.
+                </p>
+              </div>
+              <InputField
+                type="number"
+                min={1}
+                className="max-w-40"
+                placeholder="100"
+                value={values.number_of_recipients}
+                onChangeText={(value) => updateValue('number_of_recipients', value)}
+                error={!!errors.number_of_recipients}
+              />
+              {errors.number_of_recipients ? <p className="text-sm text-danger-400">{errors.number_of_recipients}</p> : null}
+              {recipientsNumber > 500 ? (
+                <div className="border-l-2 border-warning-300 pl-3.5">
+                  <p className="text-sm text-warning-300">
+                    You can send up to 500 invites or newsletters per week once you verify your calendar. Need more? You
+                    can{' '}
+                    <Link href={`/upgrade/${space._id}`} className="text-accent-400 hover:text-accent-300 transition-colors">
+                      upgrade your plan
+                    </Link>
+                    .
+                  </p>
+                </div>
+              ) : null}
+            </label>
+
+            <label className="flex flex-col gap-3">
+              <div className="space-y-1">
+                <p>Please share some information about your events.</p>
+                <p className="text-sm text-tertiary">
+                  What kinds of events are you hosting? How often? How do you market them?
+                </p>
+              </div>
+              <TextAreaField
+                className="min-h-24"
+                rows={4}
+                value={values.event_info}
+                onChangeText={(value) => updateValue('event_info', value)}
+              />
+              {errors.event_info ? <p className="text-sm text-danger-400">{errors.event_info}</p> : null}
+            </label>
+
+            <label className="flex flex-col gap-3">
+              <div className="space-y-1">
+                <p>Please share some information about your guests.</p>
+                <p className="text-sm text-tertiary">
+                  How did you build your contact list? Did people opt in to receiving emails?
+                </p>
+              </div>
+              <TextAreaField
+                className="min-h-24"
+                rows={4}
+                value={values.guests_info}
+                onChangeText={(value) => updateValue('guests_info', value)}
+              />
+              {errors.guests_info ? <p className="text-sm text-danger-400">{errors.guests_info}</p> : null}
+            </label>
+
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <Checkbox
+                  id="confirmation_1"
+                  value={values.confirmation_1}
+                  onChange={(event) => updateConfirmation('confirmation_1', event.target.checked)}
+                >
+                  <span>
+                    I confirm I will not import or contact people with inactive email addresses or who have
+                    unsubscribed.
+                  </span>
+                </Checkbox>
+                {errors.confirmation_1 ? <p className="text-sm text-danger-400">{errors.confirmation_1}</p> : null}
+              </div>
+
+              <div className="space-y-1">
+                <Checkbox
+                  id="confirmation_2"
+                  value={values.confirmation_2}
+                  onChange={(event) => updateConfirmation('confirmation_2', event.target.checked)}
+                >
+                  <span>I confirm that I will only message people who have opted in and consented to receiving emails.</span>
+                </Checkbox>
+                {errors.confirmation_2 ? <p className="text-sm text-danger-400">{errors.confirmation_2}</p> : null}
               </div>
             </div>
-          )}
-
-          {!!space && !loadingVerification && showHistory && !!verificationSubmission && (
-            <VerificationSubmissionStatusCard
-              submission={verificationSubmission}
-              onRejectedAction={() => setForceVerify(true)}
-            />
-          )}
-
-          {!!space && !loadingVerification && !showHistory && (
-            <VerifyCommunityFormFields
-              formId={form.formId}
-              space={space}
-              values={form.values}
-              errors={form.errors}
-              recipientsNumber={form.recipientsNumber}
-              onChangeValue={form.onChangeValue}
-              onToggleValue={form.onToggleValue}
-              onSubmit={form.onSubmit}
-            />
-          )}
+          </form>
         </div>
       </Pane.Content>
 
-      {!!space && !loadingVerification && !showHistory && (
-        <Pane.Footer>
-          <div className="border-t border-card-border p-4">
-            <Button
-              form={form.formId}
-              type="submit"
-              variant="secondary"
-              iconLeft="icon-done"
-              className="w-full justify-center"
-              loading={form.loading}
-              disabled={!form.canSubmit || form.loading}
-            >
-              Submit Request
-            </Button>
-          </div>
-        </Pane.Footer>
-      )}
+      <Pane.Footer>
+        <div className="border-t border-card-border p-4">
+          <Button
+            form={formId}
+            type="submit"
+            variant="secondary"
+            iconLeft="icon-done"
+            className="w-full justify-center"
+            loading={loading}
+          >
+            Submit Request
+          </Button>
+        </div>
+      </Pane.Footer>
     </Pane.Root>
-  );
-}
-
-type FormValues = {
-  number_of_recipients: string;
-  event_info: string;
-  guests_info: string;
-  confirmation_1: boolean;
-  confirmation_2: boolean;
-};
-
-type FormErrors = Partial<Record<keyof FormValues, string>>;
-
-function useVerifyCommunityForm({
-  space,
-  enabled,
-  onCompleted,
-}: {
-  space?: Space;
-  enabled: boolean;
-  onCompleted: () => Promise<void> | void;
-}) {
-  const [values, setValues] = React.useState<FormValues>({
-    number_of_recipients: '',
-    event_info: '',
-    guests_info: '',
-    confirmation_1: false,
-    confirmation_2: false,
-  });
-  const [errors, setErrors] = React.useState<FormErrors>({});
-  const formId = React.useId();
-
-  const [createVerificationSubmission, { loading }] = useMutation(CreateSpaceVerificationSubmissionDocument, {
-    onComplete: async () => {
-      toast.success('Verification request sent!');
-      await onCompleted();
-    },
-    onError: () => {
-      toast.error('Failed to send verification request');
-    },
-  });
-
-  const recipientsNumber = Number(values.number_of_recipients);
-  const canSubmit =
-    Number.isFinite(recipientsNumber) &&
-    recipientsNumber > 0 &&
-    !!values.event_info.trim() &&
-    !!values.guests_info.trim() &&
-    values.confirmation_1 &&
-    values.confirmation_2;
-
-  const validate = () => {
-    const nextErrors: FormErrors = {};
-
-    if (!values.number_of_recipients || Number.isNaN(recipientsNumber) || recipientsNumber <= 0) {
-      nextErrors.number_of_recipients = 'Please enter a valid number.';
-    }
-
-    if (!values.event_info.trim()) {
-      nextErrors.event_info = 'Please share information about your events.';
-    }
-
-    if (!values.guests_info.trim()) {
-      nextErrors.guests_info = 'Please share information about your guests.';
-    }
-
-    if (!values.confirmation_1) {
-      nextErrors.confirmation_1 = 'Please confirm this requirement.';
-    }
-
-    if (!values.confirmation_2) {
-      nextErrors.confirmation_2 = 'Please confirm this requirement.';
-    }
-
-    setErrors(nextErrors);
-    return Object.keys(nextErrors).length === 0;
-  };
-
-  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (!enabled || !space || !validate()) {
-      return;
-    }
-
-    await createVerificationSubmission({
-      variables: {
-        input: {
-          space: space._id,
-          number_of_recipients: recipientsNumber,
-          event_info: values.event_info.trim(),
-          guests_info: values.guests_info.trim(),
-          confirmation_1: values.confirmation_1,
-          confirmation_2: values.confirmation_2,
-        },
-      },
-    });
-  };
-
-  const onChangeValue = React.useCallback((field: keyof FormValues, value: string) => {
-    setValues((prev) => ({ ...prev, [field]: value }));
-  }, []);
-
-  const onToggleValue = React.useCallback((field: 'confirmation_1' | 'confirmation_2', checked: boolean) => {
-    setValues((prev) => ({ ...prev, [field]: checked }));
-  }, []);
-
-  return {
-    canSubmit,
-    errors,
-    formId,
-    loading,
-    onChangeValue,
-    onSubmit,
-    onToggleValue,
-    recipientsNumber,
-    values,
-  };
-}
-
-function VerifyCommunityFormFields({
-  formId,
-  space,
-  values,
-  errors,
-  recipientsNumber,
-  onChangeValue,
-  onToggleValue,
-  onSubmit,
-}: {
-  formId: string;
-  space: Space;
-  values: FormValues;
-  errors: FormErrors;
-  recipientsNumber: number;
-  onChangeValue: (field: 'number_of_recipients' | 'event_info' | 'guests_info', value: string) => void;
-  onToggleValue: (field: 'confirmation_1' | 'confirmation_2', checked: boolean) => void;
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => Promise<void>;
-}) {
-  const completedInfo = !!space.image_avatar_expanded && !!space.description;
-
-  return (
-    <form id={formId} onSubmit={onSubmit} className="max-w-128 w-full flex flex-col gap-6">
-      <div className="rounded-md border border-card-border bg-card px-4 py-3">
-        <div className="flex items-center gap-3">
-          <div className="size-9 rounded-sm border border-card-border overflow-hidden shrink-0 bg-(--btn-tertiary) flex items-center justify-center">
-            {space.image_avatar_expanded ? (
-              <img
-                alt={space.title || 'Space avatar'}
-                className="size-full object-cover"
-                src={generateUrl(space.image_avatar_expanded, { resize: { width: 72, height: 72, fit: 'cover' } })}
-              />
-            ) : (
-              <i aria-hidden="true" className="icon-user-group-outline size-5 text-tertiary" />
-            )}
-          </div>
-
-          <div className="space-y-0.5 min-w-0">
-            <p className="text-xs text-tertiary">For Community</p>
-            <p className="truncate">{space.title}</p>
-          </div>
-        </div>
-
-        {!completedInfo && (
-          <div className="mt-3 pl-12 space-y-3">
-            <div className="border-t border-card-border" />
-            <div className="space-y-2">
-              <p className="text-sm text-tertiary">
-                To ensure timely verification, please complete your community information with a profile picture and
-                description.
-              </p>
-              <Link
-                href={`/s/manage/${space.slug || space._id}/settings`}
-                className="inline-flex items-center gap-1 text-sm text-accent-400 hover:text-accent-300 transition-colors"
-              >
-                <span>Complete Community Info</span>
-                <i aria-hidden="true" className="icon-arrow-outward size-4.5" />
-              </Link>
-            </div>
-          </div>
-        )}
-      </div>
-
-      <label className="flex flex-col gap-3">
-        <div className="space-y-1">
-          <p>How many people would you like to invite or send newsletters to?</p>
-          <p className="text-sm text-tertiary">
-            Please share an estimate of the number of messages you plan to send at once.
-          </p>
-        </div>
-        <InputField
-          type="number"
-          min={1}
-          className="max-w-40"
-          placeholder="100"
-          value={values.number_of_recipients}
-          onChangeText={(value) => onChangeValue('number_of_recipients', value)}
-          error={!!errors.number_of_recipients}
-        />
-        {errors.number_of_recipients && <p className="text-sm text-danger-400">{errors.number_of_recipients}</p>}
-        {recipientsNumber > 500 && (
-          <div className="border-l-2 border-warning-300 pl-3.5">
-            <p className="text-sm text-warning-300">
-              You can send up to 500 invites or newsletters per week once you verify your calendar. Need more? You can{' '}
-              <Link href={`/upgrade/${space._id}`} className="text-accent-400 hover:text-accent-300 transition-colors">
-                upgrade your plan
-              </Link>
-              .
-            </p>
-          </div>
-        )}
-      </label>
-
-      <label className="flex flex-col gap-3">
-        <div className="space-y-1">
-          <p>Please share some information about your events.</p>
-          <p className="text-sm text-tertiary">What kinds of events are you hosting? How often? How do you market them?</p>
-        </div>
-        <TextAreaField
-          className="min-h-24"
-          rows={4}
-          value={values.event_info}
-          onChangeText={(value) => onChangeValue('event_info', value)}
-        />
-        {errors.event_info && <p className="text-sm text-danger-400">{errors.event_info}</p>}
-      </label>
-
-      <label className="flex flex-col gap-3">
-        <div className="space-y-1">
-          <p>Please share some information about your guests.</p>
-          <p className="text-sm text-tertiary">
-            How did you build your contact list? Did people opt in to receiving emails?
-          </p>
-        </div>
-        <TextAreaField
-          className="min-h-24"
-          rows={4}
-          value={values.guests_info}
-          onChangeText={(value) => onChangeValue('guests_info', value)}
-        />
-        {errors.guests_info && <p className="text-sm text-danger-400">{errors.guests_info}</p>}
-      </label>
-
-      <div className="space-y-4">
-        <div className="space-y-1">
-          <Checkbox
-            id="confirmation_1"
-            value={values.confirmation_1}
-            onChange={(event) => onToggleValue('confirmation_1', event.target.checked)}
-          >
-            <span>I confirm I will not import or contact people with inactive email addresses or who have unsubscribed.</span>
-          </Checkbox>
-          {errors.confirmation_1 && <p className="text-sm text-danger-400">{errors.confirmation_1}</p>}
-        </div>
-
-        <div className="space-y-1">
-          <Checkbox
-            id="confirmation_2"
-            value={values.confirmation_2}
-            onChange={(event) => onToggleValue('confirmation_2', event.target.checked)}
-          >
-            <span>I confirm that I will only message people who have opted in and consented to receiving emails.</span>
-          </Checkbox>
-          {errors.confirmation_2 && <p className="text-sm text-danger-400">{errors.confirmation_2}</p>}
-        </div>
-      </div>
-    </form>
   );
 }


### PR DESCRIPTION
## What
- Moved community verification from a standalone manage page into a side pane flow.
- Updated the newsletters manage page to open the verification pane instead of routing to `/verify`.
- Added a shared `VerificationSubmissionStatusCard` and reused it in both the pane and the newsletters page.
- Show the “Verification Request Received” state on the newsletters page when a verification submission is pending.
- Auto-close the verification pane after a submission is created and the refetch confirms the request-received state.
- Updated the shared `Button` typing to use `React.ButtonHTMLAttributes` so pane footer actions can submit forms via the `form` attribute.
- Removed the standalone verify route/page.

## Why
- Keeps the verification flow inside the existing manage-pane UX instead of bouncing users to a separate page.
- Makes newsletter gating clearer by reflecting pending verification status instead of repeatedly asking users to verify again.
- Reduces duplicate UI by sharing the verification status card between the pane and the page-level newsletter state.

## How
- Added `VerifyCommunityPane` as the only verification entry point and wired the newsletter CTA to `drawer.open(...)`.
- Extracted the verification status UI into `VerificationSubmissionStatusCard`.
- Structured the pane to follow existing patterns with `Pane.Header`, `Pane.Content`, and `Pane.Footer`.
- Submitted the pane form from the footer button using `form={formId}` after broadening the shared button props typing.
- Used the verification submission state to branch between:
  - approved: newsletter access
  - pending: received-status card
  - rejected or no submission: verify CTA
- Assumption: this PR describes the current branch state after the standalone test file was removed.

## Designs
- N/A

## Test Steps
- [ ] Go to a community manage newsletters page for an unverified community.
- [ ] Confirm clicking `Verify` opens a side pane instead of navigating to a standalone verify page.
- [ ] Submit a verification request from the pane.
- [ ] Confirm the pane closes after the request is submitted and refetched successfully.
- [ ] Reopen the newsletters page while the request is pending.
- [ ] Confirm the page shows `Verification Request Received` instead of the generic verify warning.
- [ ] Confirm approved communities can still access newsletter drafts as before.
- [ ] Confirm rejected submissions still allow the user to submit another request from the pane.

## Other Notes
- Automated test coverage for this flow was removed in the final state.
- No design artifact was provided for the new pane/status presentation.
