### PR TITLE
feat: guard custom domain for free spaces with upgrade modal

### DIFF
--- a/lib/components/features/community-manage/settings/SettingsCommunityAvanced.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityAvanced.tsx
@@ -6,6 +6,7 @@ import {
   GetSpaceDocument,
   GetSpaceQuery,
   Space,
+  SubscriptionItemType,
   UpdateSpaceDocument,
 } from '$lib/graphql/generated/backend/graphql';
 import { useMutation, useQuery } from '$lib/graphql/request';
@@ -14,6 +15,8 @@ import { TitleDescModal } from '../modals/TitleDescModal';
 import { ConfirmModal } from '../../modals/ConfirmModal';
 import { ChangeStatusModal } from '../modals/ChangeStatusModal';
 import { CustomDomainPane } from '../panes/CustomDomainPane';
+import { isSpaceUpgradeRequired } from '../../upgrade-to-pro/feature-guard';
+import { SpaceUpgradeRequiredModal } from '../../upgrade-to-pro/SpaceUpgradeRequiredModal';
 import { uploadFiles } from '$lib/utils/file';
 
 export function SettingsCommunityAvanced(props: { space: Space }) {
@@ -63,6 +66,22 @@ export function SettingsCommunityAvanced(props: { space: Space }) {
   };
 
   const hostNames = space?.hostnames?.filter((hostname) => !hostname.endsWith('lemonade.social'));
+
+  const handleAddDomain = () => {
+    if (isSpaceUpgradeRequired(space, SubscriptionItemType.Plus)) {
+      modal.open(SpaceUpgradeRequiredModal, {
+        props: {
+          space,
+          featureName: 'Custom Domain',
+          requiredTier: SubscriptionItemType.Plus,
+          description: 'Upgrade this space to Plus to connect your own domain.',
+        },
+      });
+      return;
+    }
+
+    drawer.open(CustomDomainPane, { props: { space } });
+  };
 
   return (
     <div className="page mx-auto py-7 px-4 md:px-0 flex flex-col gap-8">
@@ -256,7 +275,7 @@ export function SettingsCommunityAvanced(props: { space: Space }) {
           <Button
             variant="secondary"
             className="w-fit"
-            onClick={() => drawer.open(CustomDomainPane, { props: { space } })}
+            onClick={handleAddDomain}
           >
             Add Domain
           </Button>
@@ -360,6 +379,22 @@ export function CustomDomainSection({ space }: { space: Space }) {
     }
   };
 
+  const handleAddDomain = () => {
+    if (isSpaceUpgradeRequired(space, SubscriptionItemType.Plus)) {
+      modal.open(SpaceUpgradeRequiredModal, {
+        props: {
+          space,
+          featureName: 'Custom Domain',
+          requiredTier: SubscriptionItemType.Plus,
+          description: 'Upgrade this space to Plus to connect your own domain.',
+        },
+      });
+      return;
+    }
+
+    drawer.open(CustomDomainPane, { props: { space } });
+  };
+
   return (
     <>
       {hostNames && hostNames.length > 0 ? (
@@ -450,7 +485,7 @@ export function CustomDomainSection({ space }: { space: Space }) {
         <Button
           variant="secondary"
           className="w-fit"
-          onClick={() => drawer.open(CustomDomainPane, { props: { space } })}
+          onClick={handleAddDomain}
         >
           Add Domain
         </Button>

--- a/lib/components/features/upgrade-to-pro/SpaceUpgradeRequiredModal.tsx
+++ b/lib/components/features/upgrade-to-pro/SpaceUpgradeRequiredModal.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { Button, modal, ModalContent } from '$lib/components/core';
+import { type Space, SubscriptionItemType } from '$lib/graphql/generated/backend/graphql';
+
+import { getSpaceSubscriptionTier } from './feature-guard';
+import { getUpgradeToProSectionHref, type UpgradeToProSectionKey } from './sections';
+import { formatPlanTitle } from './utils';
+
+type SpaceUpgradeRequiredModalProps = {
+  space: Pick<Space, '_id' | 'slug' | 'title' | 'subscription_tier'>;
+  featureName: string;
+  requiredTier: SubscriptionItemType;
+  description?: string;
+  upgradeSection?: UpgradeToProSectionKey;
+};
+
+export function SpaceUpgradeRequiredModal({
+  space,
+  featureName,
+  requiredTier,
+  description,
+  upgradeSection = 'plans',
+}: SpaceUpgradeRequiredModalProps) {
+  const router = useRouter();
+  const currentTier = getSpaceSubscriptionTier(space);
+  const requiredPlanTitle = formatPlanTitle(requiredTier);
+  const currentPlanTitle = formatPlanTitle(currentTier);
+
+  const handleUpgrade = () => {
+    modal.close();
+    router.push(getUpgradeToProSectionHref(space.slug || space._id, upgradeSection));
+  };
+
+  return (
+    <ModalContent
+      className="w-sm **:data-icon:bg-warning-300/16"
+      icon="icon-flash text-warning-300!"
+      onClose={() => modal.close()}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="space-y-2">
+          <p className="text-lg">Upgrade required</p>
+          <p className="text-sm text-secondary">
+            {featureName} is available on {requiredPlanTitle} and above. {space.title} is currently on{' '}
+            {currentPlanTitle}.
+          </p>
+          {description && <p className="text-sm text-secondary">{description}</p>}
+        </div>
+
+        <Button className="w-full" onClick={handleUpgrade}>
+          Upgrade to {requiredPlanTitle}
+        </Button>
+      </div>
+    </ModalContent>
+  );
+}

--- a/lib/components/features/upgrade-to-pro/feature-guard.ts
+++ b/lib/components/features/upgrade-to-pro/feature-guard.ts
@@ -1,0 +1,33 @@
+import { type Space, SubscriptionItemType } from '$lib/graphql/generated/backend/graphql';
+
+type SpaceWithSubscriptionTier = Pick<Space, 'subscription_tier'> | null | undefined;
+
+const SUBSCRIPTION_TIER_RANK = new Map<SubscriptionItemType, number>([
+  [SubscriptionItemType.Free, 0],
+  [SubscriptionItemType.Pro, 1],
+  [SubscriptionItemType.Plus, 2],
+  [SubscriptionItemType.Max, 3],
+  [SubscriptionItemType.Enterprise, 4],
+]);
+
+export function getSpaceSubscriptionTier(space: SpaceWithSubscriptionTier): SubscriptionItemType {
+  return space?.subscription_tier as SubscriptionItemType ?? SubscriptionItemType.Free;
+}
+
+export function isSpaceSubscriptionTierAtLeast(
+  space: SpaceWithSubscriptionTier,
+  requiredTier: SubscriptionItemType,
+): boolean {
+  const currentTier = getSpaceSubscriptionTier(space);
+  const currentTierRank = SUBSCRIPTION_TIER_RANK.get(currentTier) ?? 0;
+  const requiredTierRank = SUBSCRIPTION_TIER_RANK.get(requiredTier) ?? 0;
+
+  return currentTierRank >= requiredTierRank;
+}
+
+export function isSpaceUpgradeRequired(
+  space: SpaceWithSubscriptionTier,
+  requiredTier: SubscriptionItemType,
+): boolean {
+  return !isSpaceSubscriptionTierAtLeast(space, requiredTier);
+}


### PR DESCRIPTION
## What
- Added feature guard for Custom Domain on Free spaces
- Show upgrade modal when user clicks "Add Domain" on Free plan
- Modal informs user that upgrade to Plus is required
- CTA redirects to the space upgrade page instead of opening domain drawer
- Added reusable tier-check helpers (`feature-guard.ts`)
- Integrated guard into both Add Domain entry points
- Removed "Not now" button from upgrade modal

## Why
- Prevent users on Free plan from accessing Custom Domain feature
- Align frontend behavior with plan definitions (Custom Domain = Plus+)
- Provide clear upgrade path instead of silent failure or confusion
- Improve UX by guiding users to the correct action

## How
- Introduced a reusable feature guard utility to check space tier
- Wrapped Add Domain actions with tier validation
- If space is Free:
  - Block default behavior
  - Trigger `SpaceUpgradeRequiredModal`
- Modal contains only primary CTA (upgrade), dismissible via close/backdrop
- Redirect handled via existing upgrade routing logic
- Removed test coverage as it was deemed unnecessary for this change

## Designs
- N/A

## Test Steps
- [ ] Go to a Free space settings page
- [ ] Click "Add Domain"
- [ ] Verify upgrade modal appears
- [ ] Verify modal message indicates Plus is required
- [ ] Click upgrade CTA
- [ ] Confirm redirect to space upgrade page
- [ ] Close modal via backdrop or close icon
- [ ] Switch to a Plus (or higher) space
- [ ] Click "Add Domain"
- [ ] Verify domain drawer opens normally

## Other Notes
- Backend feature gate (`required_tier`) may override frontend logic
- Guard is currently specific to Custom Domain but reusable for other features