### PR TITLE
fix(session): migrate inline documents to codegen imports; fix 6 runtime bugs on sessions page

### DIFF
--- a/__tests__/session-revocation.test.tsx
+++ b/__tests__/session-revocation.test.tsx
@@ -343,7 +343,7 @@ describe('Active Sessions page', () => {
 
     mockMutate
       .mockResolvedValueOnce({ data: { getMyActiveSessions: mockSessions } })
-      .mockResolvedValueOnce({ data: { revokeMySession: mockSessions[1] } });
+      .mockResolvedValueOnce({ data: { revokeMySession: true } });
 
     const ActiveSessionsPage = (await import(
       '../app/[domain]/(default)/settings/security/sessions/page'

--- a/app/[domain]/(default)/settings/security/sessions/page.tsx
+++ b/app/[domain]/(default)/settings/security/sessions/page.tsx
@@ -6,96 +6,18 @@ import { Button, modal, toast } from '$lib/components/core';
 import { ModalContent } from '$lib/components/core/dialog/modal';
 import { useMutation } from '$lib/graphql/request';
 import { getErrorMessage } from '$lib/utils/error';
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import {
+  ActiveSessionFieldsFragmentDoc,
+  GetMyActiveSessionsDocument,
+  RevokeMySessionDocument,
+  RequestStepUpVerificationDocument,
+  VerifyStepUpVerificationDocument,
+  RevokeAllOtherSessionsDocument,
+  type ActiveSessionFieldsFragment,
+} from '$lib/graphql/generated/backend/graphql';
+import { useFragment } from '$lib/graphql/generated/backend/fragment-masking';
 
-interface ActiveSession {
-  _id: string;
-  kratos_identity_id: string;
-  kratos_session_id: string;
-  device_name: string;
-  device_model: string;
-  os: string;
-  app_version: string;
-  client_type: string;
-  ip_address: string;
-  last_active_at: string;
-  is_current: boolean;
-  has_active_websocket: boolean;
-}
-
-// GraphQL operations defined as plain strings to avoid shipping the ~300KB graphql
-// parser to the client bundle. graphql-request accepts string queries at runtime.
-// TODO: Replace with codegen-generated TypedDocumentNode imports after running `yarn codegen`.
-
-const ACTIVE_SESSION_FIELDS = `
-  _id
-  kratos_identity_id
-  kratos_session_id
-  device_name
-  device_model
-  os
-  app_version
-  client_type
-  ip_address
-  last_active_at
-  is_current
-  has_active_websocket
-`;
-
-const GetMyActiveSessionsDocument = `
-  query getMyActiveSessions {
-    getMyActiveSessions {
-      ${ACTIVE_SESSION_FIELDS}
-    }
-  }
-` as unknown as TypedDocumentNode<
-  { getMyActiveSessions: ActiveSession[] },
-  Record<string, never>
->;
-
-const RevokeMySessionDocument = `
-  mutation revokeMySession($sessionId: MongoID!) {
-    revokeMySession(session_id: $sessionId) {
-      ${ACTIVE_SESSION_FIELDS}
-    }
-  }
-` as unknown as TypedDocumentNode<
-  { revokeMySession: ActiveSession },
-  { sessionId: string }
->;
-
-const RequestStepUpVerificationDocument = `
-  mutation requestStepUpVerification {
-    requestStepUpVerification {
-      success
-    }
-  }
-` as unknown as TypedDocumentNode<
-  { requestStepUpVerification: { success: boolean } },
-  Record<string, never>
->;
-
-const VerifyStepUpVerificationDocument = `
-  mutation verifyStepUpVerification($code: String!) {
-    verifyStepUpVerification(code: $code) {
-      step_up_token
-    }
-  }
-` as unknown as TypedDocumentNode<
-  { verifyStepUpVerification: { step_up_token: string } },
-  { code: string }
->;
-
-const RevokeAllOtherSessionsDocument = `
-  mutation revokeAllOtherSessions($stepUpToken: String!) {
-    revokeAllOtherSessions(step_up_token: $stepUpToken) {
-      revoked_count
-    }
-  }
-` as unknown as TypedDocumentNode<
-  { revokeAllOtherSessions: { revoked_count: number } },
-  { stepUpToken: string }
->;
+type ActiveSession = ActiveSessionFieldsFragment;
 
 // ---- Relative time helper ----
 function relativeTime(iso: string): string {
@@ -136,7 +58,7 @@ function StepUpVerificationModal({ onSuccess }: { onSuccess: (token: string) => 
     setLoading(true);
     try {
       const { data } = await verifyCode({ variables: { code } });
-      const token = data?.verifyStepUpVerification?.step_up_token;
+      const token = data?.verifyStepUpVerification;
       if (!token) {
         toast.error('Verification failed');
         setLoading(false);
@@ -292,7 +214,7 @@ export default function ActiveSessionsPage() {
     try {
       const { data } = await fetchSessions({});
       if (data?.getMyActiveSessions) {
-        setSessions(data.getMyActiveSessions);
+        setSessions(useFragment(ActiveSessionFieldsFragmentDoc, data.getMyActiveSessions));
       }
     } catch (error: unknown) {
       toast.error(getErrorMessage(error));

--- a/lib/hooks/useLogout.ts
+++ b/lib/hooks/useLogout.ts
@@ -2,18 +2,12 @@
 import { useContext } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import * as Sentry from '@sentry/nextjs';
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { ory } from '$lib/utils/ory';
 import { hydraClientIdAtom, sessionAtom } from '$lib/jotai';
 import { GraphQLWSContext } from '$lib/graphql/subscription/context';
 import { useMutation } from '$lib/graphql/request';
-
-const RevokeCurrentSessionDocument = `
-  mutation revokeCurrentSession {
-    revokeCurrentSession
-  }
-` as unknown as TypedDocumentNode<{ revokeCurrentSession: boolean }, Record<string, never>>;
+import { RevokeCurrentSessionDocument } from '$lib/graphql/generated/backend/graphql';
 
 const REVOKE_TIMEOUT_MS = 2000;
 


### PR DESCRIPTION
## Summary

Follow-up to session.gql schema alignment (merged `488165b0`). Migrates the two remaining inline `TypedDocumentNode` consumers to codegen imports AND fixes 6 runtime bugs that made the sessions page and step-up flow **entirely non-functional on staging today**.

## Runtime bugs fixed

All 4 mutations on `app/[domain]/(default)/settings/security/sessions/page.tsx` were broken on master:

1. **`verifyStepUpVerification`** — code accessed `data?.verifyStepUpVerification?.step_up_token`, but backend returns raw `String`. Result was always `undefined` → step-up flow 100% broken
2. **`revokeMySession` arg**: `session_id` (snake_case) — server rejected; new schema requires `sessionId`
3. **`revokeAllOtherSessions` arg**: `step_up_token` — server rejected; needs `stepUpToken`
4. **Selection set on `Boolean` return** (`revokeMySession`, `requestStepUpVerification`) — GraphQL server rejected
5. **Selection set on `String` return** (`verifyStepUpVerification`) — GraphQL server rejected
6. **Selection set on `Int` return** (`revokeAllOtherSessions`) — GraphQL server rejected

## Code hygiene

- Removed 5 inline `TypedDocumentNode` casts (page.tsx) + 1 inline cast (useLogout.ts)
- Imports from `$lib/graphql/generated/backend/graphql`:
  - `GetMyActiveSessionsDocument`, `RevokeMySessionDocument`, `RequestStepUpVerificationDocument`, `VerifyStepUpVerificationDocument`, `RevokeAllOtherSessionsDocument`, `RevokeCurrentSessionDocument`
  - `ActiveSessionFieldsFragmentDoc` + `type ActiveSessionFieldsFragment` + `useFragment`
- Local non-null `ActiveSession` interface replaced with codegen-generated `ActiveSessionFieldsFragment` (which correctly marks `kratos_session_id`, `device_name`, `device_model`, `os`, `app_version`, `locale` as nullable — render sites already tolerate null via `|| 'Unknown'` fallbacks)
- Fragment-masking unwrap via `useFragment(ActiveSessionFieldsFragmentDoc, ...)` — same pattern as 7 other consumers (EventGuestSide, ManageLayoutContent, etc.)

## Test update

`__tests__/session-revocation.test.tsx:346` — `mockMutate.mockResolvedValueOnce({ data: { revokeMySession: mockSessions[1] } })` → `{ revokeMySession: true }` (matches scalar Boolean return)

## Files

| File | Change |
|---|---|
| `app/[domain]/(default)/settings/security/sessions/page.tsx` | Remove inline docs; import from codegen; fix field access + arg renames; fragment unwrap |
| `lib/hooks/useLogout.ts` | Remove inline doc; import from codegen (consistency only — was not runtime-broken) |
| `__tests__/session-revocation.test.tsx` | Update mock fixture for scalar boolean return |

**+15 / -99 LOC** (net ~84 reduction).

## Test plan

- [x] `yarn test --run __tests__/session-revocation.test.tsx` → 14/14 (5x stress, stable)
- [x] `yarn test --run` (full) → 223/223 passing
- [x] `yarn lint` → 0 errors (733 pre-existing warnings)
- [x] `yarn typecheck:changed --base master --head HEAD` → clean (3/3)
- [x] Hostile audit → **ZERO findings** (20/20 checks)

## References

- Predecessor: session.gql schema alignment merged `488165b0`
- Backend schema: lemonade-backend `src/app/models/active-session.ts` + `src/graphql/resolvers/{session,step-up}.ts`

## Pipeline

- ✅ DISCOVERY-SESSION-CONSUMERS-1 CONFIRMED
- ✅ Gate IG-A
- ✅ IMPL-SESSION-CONSUMERS-1 (\`7290b47f\`)
- ✅ HOSTILE-AUDIT → ZERO findings
- ⏳ Karen review next