### PR TITLE
fix: correct community slug availability validation

### DIFF
--- a/lib/components/features/community-manage/settings/SettingsCommunityDisplay.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityDisplay.tsx
@@ -86,7 +86,7 @@ export function CommunityDetailForm({ space }: { space: Space }) {
 
   const [slug, setSlug] = React.useState(space.slug || '');
   const [checking, setChecking] = React.useState(false);
-  const [canUseSpaceSlug, setCanUseSpaceSlug] = React.useState(false);
+  const [canUseSpaceSlug, setCanUseSpaceSlug] = React.useState<boolean | null>(null);
 
   const { client } = useClient();
   const { __typename, ...address } = space.address || {};
@@ -96,6 +96,9 @@ export function CommunityDetailForm({ space }: { space: Space }) {
     setValue,
     control,
     reset,
+    setError,
+    trigger,
+    getValues,
     formState: { errors, dirtyFields, isDirty },
   } = useForm<FormValues>({
     defaultValues: {
@@ -199,17 +202,29 @@ export function CommunityDetailForm({ space }: { space: Space }) {
   };
 
   const debouncedFetchData = React.useCallback(
-    debounce(async (query) => {
+    debounce(async (query: string) => {
+      const normalizedSlug = kebabCase(query);
+
       try {
-        const { data } = await client.query({ query: CheckSpaceSlugDocument, variables: { slug: query } });
+        const { data } = await client.query({ query: CheckSpaceSlugDocument, variables: { slug: normalizedSlug } });
+        if (getValues('slug') !== query) return;
+
+        if (!data?.canUseSpaceSlug) {
+          setError('slug', { type: 'validate', message: 'This URL is already taken.' });
+        } else {
+          await trigger('slug');
+        }
+
         setCanUseSpaceSlug(!!data?.canUseSpaceSlug);
       } catch (err) {
         Sentry.captureException(err);
       } finally {
-        setChecking(false);
+        if (getValues('slug') === query) {
+          setChecking(false);
+        }
       }
     }, 500),
-    [],
+    [client, getValues, setError, trigger],
   );
 
   const onSubmit = async (values: FormValues) => {
@@ -235,16 +250,21 @@ export function CommunityDetailForm({ space }: { space: Space }) {
     if (slug.length < 3 || !dirtyFields.slug) return '';
 
     if (checking) return 'icon-spin animate-spin align-items-center text-warning-400 flex h-full mx-2';
-    if (canUseSpaceSlug) {
+    if (canUseSpaceSlug === true) {
       return 'icon-richtext-check text-success-400 align-items-center flex h-full mx-2';
-    } else {
+    }
+    if (canUseSpaceSlug === false) {
       return 'icon-x text-danger-400 align-items-center flex h-full mx-2';
     }
+
+    return '';
   };
 
   React.useEffect(() => {
     setValue('theme_data', state, { shouldDirty: true });
   }, [state]);
+
+  React.useEffect(() => () => debouncedFetchData.cancel(), [debouncedFetchData]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -362,18 +382,19 @@ export function CommunityDetailForm({ space }: { space: Space }) {
                         setValue('slug', value, { shouldDirty: true, shouldValidate: true });
                         if (value.length > 2) {
                           setChecking(true);
+                          setCanUseSpaceSlug(null);
                           debouncedFetchData(value);
+                        } else {
+                          setChecking(false);
+                          setCanUseSpaceSlug(null);
+                          debouncedFetchData.cancel();
                         }
                       }}
                       right={{
                         icon: getIconSlugField(),
                       }}
-                      error={dirtyFields.slug && (!!errors.slug?.message || !canUseSpaceSlug)}
-                      hint={
-                        !checking && dirtyFields.slug && (!!errors.slug?.message || !canUseSpaceSlug)
-                          ? errors.slug?.message || 'This URL is already taken.'
-                          : ''
-                      }
+                      error={dirtyFields.slug && !!errors.slug?.message}
+                      hint={dirtyFields.slug ? errors.slug?.message || '' : ''}
                     />
                   )}
                 />

--- a/lib/components/features/community/CommunityForm.tsx
+++ b/lib/components/features/community/CommunityForm.tsx
@@ -100,6 +100,8 @@ export function CommunityFormContent({
     control,
     setValue,
     setError,
+    trigger,
+    getValues,
     formState: { errors, dirtyFields },
   } = form;
 
@@ -111,37 +113,47 @@ export function CommunityFormContent({
 
   const [slug, setSlug] = React.useState('');
   const [checking, setChecking] = React.useState(false);
-  const [canUseSpaceSlug, setCanUseSpaceSlug] = React.useState(false);
+  const [canUseSpaceSlug, setCanUseSpaceSlug] = React.useState<boolean | null>(null);
 
   const { client } = useClient();
 
   const debouncedFetchData = React.useCallback(
-    debounce(async (query) => {
-      try {
-        const { data } = await client.query({ query: CheckSpaceSlugDocument, variables: { slug: query } });
+    debounce(async (query: string) => {
+      const normalizedSlug = kebabCase(query);
 
-        if (!!data?.canUseSpaceSlug) {
+      try {
+        const { data } = await client.query({ query: CheckSpaceSlugDocument, variables: { slug: normalizedSlug } });
+        if (getValues('slug') !== query) return;
+
+        if (!data?.canUseSpaceSlug) {
           setError('slug', { type: 'validate', message: 'This URL is already taken.' });
+        } else {
+          await trigger('slug');
         }
         setCanUseSpaceSlug(!!data?.canUseSpaceSlug);
       } catch (err: unknown) {
         Sentry.captureException(err);
       } finally {
-        setChecking(false);
+        if (getValues('slug') === query) {
+          setChecking(false);
+        }
       }
     }, 500),
-    [],
+    [client, getValues, setError, trigger],
   );
 
   const getIconSlugField = () => {
     if (slug.length < 3) return '';
 
     if (checking) return 'icon-spin animate-spin align-items-center text-warning-400 flex h-full mx-2';
-    if (canUseSpaceSlug) {
+    if (canUseSpaceSlug === true) {
       return 'icon-richtext-check text-success-400 align-items-center flex h-full mx-2';
-    } else {
+    }
+    if (canUseSpaceSlug === false) {
       return 'icon-x text-danger-400 align-items-center flex h-full mx-2';
     }
+
+    return '';
   };
 
   const handleUpload = async (files: globalThis.File[], type: 'cover' | 'dp') => {
@@ -168,10 +180,7 @@ export function CommunityFormContent({
     }
   };
 
-  React.useEffect(() => {
-    if (!canUseSpaceSlug) {
-    }
-  }, [canUseSpaceSlug]);
+  React.useEffect(() => () => debouncedFetchData.cancel(), [debouncedFetchData]);
 
   return (
     <>
@@ -276,18 +285,19 @@ export function CommunityFormContent({
                     setValue('slug', value, { shouldDirty: true, shouldValidate: true });
                     if (value.length > 2) {
                       setChecking(true);
+                      setCanUseSpaceSlug(null);
                       debouncedFetchData(value);
+                    } else {
+                      setChecking(false);
+                      setCanUseSpaceSlug(null);
+                      debouncedFetchData.cancel();
                     }
                   }}
                   right={{
                     icon: getIconSlugField(),
                   }}
-                  error={dirtyFields.slug && (!!errors.slug?.message || !canUseSpaceSlug)}
-                  hint={
-                    dirtyFields.slug && (!!errors.slug?.message || !canUseSpaceSlug)
-                      ? errors.slug?.message || 'This URL is already taken.'
-                      : ''
-                  }
+                  error={dirtyFields.slug && !!errors.slug?.message}
+                  hint={dirtyFields.slug ? errors.slug?.message || '' : ''}
                 />
               )}
             />


### PR DESCRIPTION
## What
- Fixed community slug availability validation in the create community form.
- Fixed the same slug validation flow in community settings so create and edit behave consistently.
- Updated slug field feedback to avoid showing a conflict error when the slug is actually available.

## Why
- Community creation could incorrectly show `This URL is already taken.` for valid slugs.
- The UI could get into a contradictory state with a success checkmark and an error message at the same time.
- Keeping create and edit flows aligned reduces reviewer and user confusion around slug availability.

## How
- Corrected the `canUseSpaceSlug` handling so the form only sets a validation error when the backend reports the slug is unavailable.
- Normalized the slug before validation and ignored stale async responses when the input changed during the debounce window.
- Switched the field UI to rely on the actual form error state and reset the transient availability state when the slug input changes.
- Added debounce cleanup to prevent outdated checks from leaking into the current field state.

## Designs
- N/A

## Test Steps
- [ ] Open the create community flow.
- [ ] Enter a unique slug in the `Public URL` field.
- [ ] Confirm the field shows a success state and does not show `This URL is already taken.`
- [ ] Enter a slug that is already in use.
- [ ] Confirm the field shows the taken error state.
- [ ] Edit the slug from a taken value to an available value.
- [ ] Confirm the stale error clears and the field updates to the success state.
- [ ] Open community settings for an existing community.
- [ ] Repeat the same available and unavailable slug checks in the settings form.

## Other Notes
- No design changes are included.
- No automated regression test is included in the current branch state.
