### PR TITLE
fix: ensure configs always populated and show welcome message in AI designer

### DIFF
--- a/app/[domain]/(default)/agent/e/manage/[shortid]/page.tsx
+++ b/app/[domain]/(default)/agent/e/manage/[shortid]/page.tsx
@@ -18,7 +18,7 @@ import { EventMore } from '$lib/components/features/event-manage/EventMore';
 import { EventOverview } from '$lib/components/features/event-manage/overview/EventOverview';
 import { EventRegistration } from '$lib/components/features/event-manage/EventRegistration';
 import { EventPaymentLayout } from './EventPaymentLayout';
-import { AiConfigFieldsFragment, GetListAiConfigDocument } from '$lib/graphql/generated/ai/graphql';
+import { AiConfigFieldsFragment, Config, GetListAiConfigDocument } from '$lib/graphql/generated/ai/graphql';
 import { aiChatClient } from '$lib/graphql/request/instances';
 import { isMobile } from 'react-device-detect';
 
@@ -97,6 +97,7 @@ function Content({ event, shortid }: { event: Event; shortid: string }) {
             type: AIChatActionKind.set_config,
             payload: {
               config: config._id,
+              configs: data.configs.items as Config[],
               messages: mockWelcomeEvent(event),
             },
           });

--- a/app/[domain]/(default)/agent/s/manage/[uid]/page.tsx
+++ b/app/[domain]/(default)/agent/s/manage/[uid]/page.tsx
@@ -19,7 +19,7 @@ import { CommunitySettingsLayout } from './CommunitySettingsLayout';
 import { AIChatActionKind, useAIChat } from '$lib/components/features/ai/provider';
 import { aiChat } from '$lib/components/features/ai/AIChatContainer';
 import { mockWelcomeSpace } from '$lib/components/features/ai/InputChat';
-import { AiConfigFieldsFragment, GetListAiConfigDocument } from '$lib/graphql/generated/ai/graphql';
+import { AiConfigFieldsFragment, Config, GetListAiConfigDocument } from '$lib/graphql/generated/ai/graphql';
 import { aiChatClient } from '$lib/graphql/request/instances';
 import { isMobile } from 'react-device-detect';
 import { CommunityAgents } from '$lib/components/features/community-manage/CommunityAgents';
@@ -139,7 +139,10 @@ function Content({ space, uid }: { space: Space; uid: string }) {
       onComplete: (data) => {
         if (data?.configs?.items?.length) {
           const config = data.configs.items[0] as AiConfigFieldsFragment;
-          aiChatDispatch({ type: AIChatActionKind.set_config, payload: { config: config._id } });
+          aiChatDispatch({
+            type: AIChatActionKind.set_config,
+            payload: { config: config._id, configs: data.configs.items as Config[] },
+          });
         }
       },
       skip: !space._id,

--- a/lib/components/features/ai/InputChat.tsx
+++ b/lib/components/features/ai/InputChat.tsx
@@ -10,7 +10,7 @@ import Image from 'next/image';
 import { Button, Card, drawer, Menu, MenuItem, toast } from '$lib/components/core';
 
 import { useClient, useMutation, useQuery } from '$lib/graphql/request';
-import { AiConfigFieldsFragment, GetListAiConfigDocument, RunAiChatDocument } from '$lib/graphql/generated/ai/graphql';
+import { AiConfigFieldsFragment, Config, GetListAiConfigDocument, RunAiChatDocument } from '$lib/graphql/generated/ai/graphql';
 import { aiChatClient } from '$lib/graphql/request/instances';
 import { AI_CONFIG } from '$lib/utils/constants';
 import {
@@ -149,7 +149,10 @@ export function InputChat({
               dispatch({ type: AIChatActionKind.reset });
               if (res.data?.configs?.items?.length) {
                 const config = res.data.configs.items[0] as AiConfigFieldsFragment;
-                dispatch({ type: AIChatActionKind.set_config, payload: { config: config._id } });
+                dispatch({
+                  type: AIChatActionKind.set_config,
+                  payload: { config: config._id, configs: res.data.configs.items as Config[] },
+                });
               }
             }, 2500);
           })
@@ -193,7 +196,10 @@ export function InputChat({
               dispatch({ type: AIChatActionKind.reset });
               if (res.data?.configs?.items?.length) {
                 const config = res.data.configs.items[0] as AiConfigFieldsFragment;
-                dispatch({ type: AIChatActionKind.set_config, payload: { config: config._id } });
+                dispatch({
+                  type: AIChatActionKind.set_config,
+                  payload: { config: config._id, configs: res.data.configs.items as Config[] },
+                });
               }
             }, 2500);
           })

--- a/lib/components/features/ai/manage/DesignTool.tsx
+++ b/lib/components/features/ai/manage/DesignTool.tsx
@@ -4,11 +4,14 @@ import { EventThemeBuilder } from '$lib/components/features/theme-builder/EventT
 import clsx from 'clsx';
 import React from 'react';
 import { AIChat } from '../AIChat';
-import { AIChatActionKind, useAIChat } from '../provider';
+import { AIChatActionKind, Message, useAIChat } from '../provider';
 import { TemplateTool } from './TemplateTool';
 import { SectionTool } from './SectionTool';
 import { storeManageLayout, useStoreManageLayout } from './store';
 import { AI_CONFIG } from '$lib/utils/constants';
+import { useQuery } from '$lib/graphql/request/hooks';
+import { Config, GetAiConfigDocument } from '$lib/graphql/generated/ai/graphql';
+import { aiChatClient } from '$lib/graphql/request/instances';
 
 const segments: SegmentItem<string>[] = [
   { label: 'Builder', value: 'builder', iconLeft: 'icon-cards-outline' },
@@ -21,20 +24,48 @@ export function DesignTool() {
   const state = useStoreManageLayout();
   const segment = state.designMode;
   const [_, aiChatDispatch] = useAIChat();
+  const [pageDesignerConfig, setPageDesignerConfig] = React.useState<Config | null>(null);
+
+  useQuery(
+    GetAiConfigDocument,
+    {
+      variables: { id: PAGE_DESIGNER_CONFIG_ID! },
+      onComplete: (data) => {
+        if (data?.config) {
+          setPageDesignerConfig(data.config as Config);
+        }
+      },
+      skip: !PAGE_DESIGNER_CONFIG_ID,
+    },
+    aiChatClient,
+  );
 
   React.useEffect(() => {
-    if (segment === 'ai') {
-      aiChatDispatch({
-        type: AIChatActionKind.set_config,
-        payload: { config: PAGE_DESIGNER_CONFIG_ID },
-      });
-    } else {
-      aiChatDispatch({
-        type: AIChatActionKind.set_config,
-        payload: { config: AI_CONFIG },
-      });
-    }
+    if (segment !== 'builder') return;
+    aiChatDispatch({
+      type: AIChatActionKind.set_config,
+      payload: { config: AI_CONFIG },
+    });
   }, [segment, aiChatDispatch]);
+
+  React.useEffect(() => {
+    if (segment !== 'ai' || !pageDesignerConfig) return;
+    const welcomeMessage: Message = {
+      message:
+        pageDesignerConfig.welcomeMessage ||
+        `Hi, I'm ${pageDesignerConfig.name}, your ${pageDesignerConfig.job || 'assistant'}.\nHow can I help?`,
+      role: 'assistant',
+      metadata: pageDesignerConfig.welcomeMetadata,
+    };
+    aiChatDispatch({
+      type: AIChatActionKind.set_config,
+      payload: {
+        config: PAGE_DESIGNER_CONFIG_ID,
+        configs: [pageDesignerConfig],
+        messages: [welcomeMessage],
+      },
+    });
+  }, [segment, pageDesignerConfig, aiChatDispatch]);
 
   return (
     <div className="h-full flex flex-col">

--- a/lib/components/features/ai/manage/ManageLayoutContent.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutContent.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { match } from 'ts-pattern';
 
 import { useQuery } from '$lib/graphql/request';
-import { AiConfigFieldsFragment, GetListAiConfigDocument } from '$lib/graphql/generated/ai/graphql';
+import { AiConfigFieldsFragment, Config, GetListAiConfigDocument } from '$lib/graphql/generated/ai/graphql';
 import { AIChatActionKind, useAIChat } from '../provider';
 import { aiChatClient } from '$lib/graphql/request/instances';
 import {
@@ -132,6 +132,7 @@ function ManageLayoutContent() {
             type: AIChatActionKind.set_config,
             payload: {
               config: config._id,
+              configs: data.configs.items as Config[],
               messages: event ? mockWelcomeEvent(event) : undefined,
             },
           });


### PR DESCRIPTION
## Summary

- Pass full `configs` array in `set_config` payload at all `GetListAiConfigDocument` call sites so `state.configs` is never left empty after `reset` or initial load
- In `DesignTool`, fetch the `PAGE_DESIGNER` config via `GetAiConfigDocument` (single-item query) and dispatch the welcome message explicitly when switching to AI Designer mode

## Changes

- `lib/components/features/ai/InputChat.tsx` — pass `configs` after `reset` in both `create_event` and `create_space` branches
- `lib/components/features/ai/manage/ManageLayoutContent.tsx` — pass `configs` when setting event config
- `lib/components/features/ai/manage/DesignTool.tsx` — fetch PAGE_DESIGNER config and show its welcome message on mode switch
- `app/[domain]/(default)/agent/e/manage/[shortid]/page.tsx` — pass `configs` when setting event config
- `app/[domain]/(default)/agent/s/manage/[uid]/page.tsx` — pass `configs` when setting space config

## Test plan

- [ ] Open event manage page → AI chat shows event welcome message
- [ ] Open space manage page → AI chat shows space welcome message
- [ ] Switch to AI Designer tab → chat shows PAGE_DESIGNER config's welcome message
- [ ] Switch back to Builder tab → chat resets to event config
- [ ] Create event/space via AI chat → after redirect, new config welcome message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)