### PR TITLE
chore: skip CI jobs for release please PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   lint:
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-tracker-trigger.yml
+++ b/.github/workflows/pr-tracker-trigger.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   notify:
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger PR Tracker update

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,12 @@ on:
 
 jobs:
   unit-tests:
+    if: >-
+      github.event_name == 'push' ||
+      (
+        !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
+        !startsWith(github.event.pull_request.head.ref, 'release-please--')
+      )
     name: Unit Tests
     timeout-minutes: 10
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
- Updated PR workflow jobs to skip execution for Release Please PRs.
- Added release PR detection using both the `autorelease: pending` label and the `release-please--` branch prefix.
- Preserved normal push-based unit test runs on `main` and `master`.

## Why
- Release PRs should not wait on standard contributor PR checks that are not useful for automated version bump PRs.
- Skipping these jobs reduces noise in release PRs and avoids unnecessary CI usage.
- The fallback branch-prefix check makes the skip logic more resilient if labels are delayed or missing.

## How
- Added job-level `if` conditions to `.github/workflows/lint.yml`, `.github/workflows/unit-tests.yml`, and `.github/workflows/pr-tracker-trigger.yml`.
- Used job-level gating instead of changing workflow triggers so normal PR behavior stays intact while release PR jobs are marked skipped.
- Kept `unit-tests.yml` running for `push` events and only bypassed its `pull_request` path for detected Release Please PRs.

## Designs
- N/A

## Test Steps
- [ ] Open a normal feature PR targeting `main` or `master`.
- [ ] Confirm `Lint`, `Unit Tests`, and `Notify PR Tracker` still run as usual.
- [ ] Open or inspect a Release Please PR with the `autorelease: pending` label or a `release-please--*` head branch.
- [ ] Confirm those three jobs are skipped for the release PR.
- [ ] Verify push-based unit tests on `main`/`master` still run after merge.

## Other Notes
- Assumption: Release Please PRs in this repo consistently have either the `autorelease: pending` label or a `release-please--*` branch name.
- No UI or product behavior changes are included in this PR.
