### PR TITLE
fix: page builder init, drag interactions, and theme defaults

### DIFF
--- a/lib/components/features/ai/manage/ManageLayout.tsx
+++ b/lib/components/features/ai/manage/ManageLayout.tsx
@@ -78,12 +78,13 @@ function ManageLayout({
     },
   });
 
-  const { data: pageConfigRaw, loading: loadingPageConfig } = useQuery(GetPageConfigDocument, {
+  const pageConfigShouldFetch = !!state.data?._id && !state.pageConfigId;
+  const { data: pageConfigRaw, loading: loadingPageConfig, error: pageConfigError } = useQuery(GetPageConfigDocument, {
     variables: {
       ownerType: state.layoutType === 'event' ? PageConfigOwnerType.Event : PageConfigOwnerType.Space,
       ownerId: state.data?._id,
     },
-    skip: !state.data?._id || !!state.pageConfigId,
+    skip: !pageConfigShouldFetch,
   });
 
   const pageConfigFields = useFragment(PageConfigFragmentFragmentDoc, pageConfigRaw?.getPageConfig);
@@ -95,7 +96,19 @@ function ManageLayout({
     }
   }, [pageConfigFields]);
 
-  const isLoading = loadingEvent || loadingSpace || loadingPageConfig;
+  // Guard against the brief window where loadingPageConfig is false but the fetch hasn't started
+  // yet (useQuery's loading initialises to false), and also guard against query errors so
+  // ManageLayoutContent always receives a resolved value (null = no config, object = has config).
+  const isLoading = loadingEvent || loadingSpace || loadingPageConfig ||
+    (pageConfigShouldFetch && pageConfigRaw === null && !pageConfigError);
+
+  // Resolved value passed to ManageLayoutContent:
+  //   undefined → still loading (init effect will wait)
+  //   null      → query resolved with no config or errored (init effect builds default layout)
+  //   object    → query resolved with a config (init effect deserializes it)
+  const resolvedPageConfig = pageConfigShouldFetch && (pageConfigRaw === null || pageConfigError)
+    ? null
+    : pageConfigRaw?.getPageConfig;
 
   const savedThemeAsValues = React.useMemo(() => {
     if (state.savedPageTheme) {
@@ -188,7 +201,7 @@ function ManageLayout({
           themeData={savedThemeAsValues}
         >
           <ManageLayoutToolbar />
-          <ManageLayoutContent pageConfig={pageConfigRaw?.getPageConfig}>{children}</ManageLayoutContent>
+          <ManageLayoutContent pageConfig={resolvedPageConfig}>{children}</ManageLayoutContent>
         </EventThemeProvider>
         <DrawerContainer />
       </PageEditorProvider>

--- a/lib/components/features/ai/manage/ManageLayoutContent.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutContent.tsx
@@ -39,6 +39,14 @@ import { SettingsPanel } from './SettingsPanel';
 
 const communityPreviewTabs = new Set(['design', 'preview']);
 
+const DEFAULT_EVENT_SECTIONS: PageSection[] = [
+  { id: 'event-hero', type: 'event_hero', order: 0, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'event-hero' },
+  { id: 'datetime-block', type: 'event_datetime', order: 1, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'datetime-block' },
+  { id: 'location-block', type: 'event_location_block', order: 2, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'location-block' },
+  { id: 'about', type: 'event_about', order: 3, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'about' },
+  { id: 'registration', type: 'event_registration', order: 4, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'registration' },
+];
+
 function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(false);
 
@@ -97,11 +105,15 @@ function ManageLayoutContent({
 
   const hasInitializedRef = React.useRef(false);
   React.useEffect(() => {
-    // Fire once the page config query has resolved (pageConfigData !== undefined),
-    // even when sections is empty — sectionsToNodes([]) builds a default layout.
+    // Fire once the page config query has resolved (pageConfigProp !== undefined).
+    // null  = resolved but no config exists → fall back to DEFAULT_EVENT_SECTIONS for events.
+    // object = resolved with saved sections → deserialize them.
     if (pageConfigProp === undefined || hasInitializedRef.current) return;
     try {
-      const sections = ((pageConfigData_?.sections ?? []) as unknown as PageSection[]);
+      const saved = ((pageConfigData_?.sections ?? []) as unknown as PageSection[]);
+      const sections = saved.length === 0 && state.layoutType === 'event'
+        ? DEFAULT_EVENT_SECTIONS
+        : saved;
       const nodes = sectionsToNodes(sections);
       actions.deserialize(JSON.stringify(nodes));
       actions.history.clear();
@@ -110,7 +122,7 @@ function ManageLayoutContent({
     } catch (e) {
       console.error('Failed to deserialize pageConfig sections', e);
     }
-  }, [pageConfigProp, pageConfigData_, actions]);
+  }, [pageConfigProp, pageConfigData_, actions, state.layoutType]);
 
   useQuery(
     GetListAiConfigDocument,
@@ -255,17 +267,8 @@ function ManageLayoutContent({
       resetToDefault: () => {
         const { state, actions } = editorRef.current;
         if (state.layoutType === 'event') {
-          const _event = state.data as Event;
-          const defaultSections: PageSection[] = [
-            { id: 'event-hero', type: 'event_hero', order: 0, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'event-hero' },
-            { id: 'datetime-block', type: 'event_datetime', order: 1, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'datetime-block' },
-            { id: 'location-block', type: 'event_location_block', order: 2, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'location-block' },
-            { id: 'about', type: 'event_about', order: 3, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'about' },
-            { id: 'registration', type: 'event_registration', order: 4, hidden: false, layout: { width: 'contained', padding: 'md' }, props: {}, craft_node_id: 'registration' },
-          ];
-          const nodes = sectionsToNodes(defaultSections);
+          const nodes = sectionsToNodes(DEFAULT_EVENT_SECTIONS);
           actions.deserialize(JSON.stringify(nodes));
-          // Satisfy exhaustive-deps — _event intentionally unused in default reset
         }
       },
     });

--- a/lib/components/features/ai/manage/ManageLayoutToolbar.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutToolbar.tsx
@@ -202,10 +202,14 @@ function ManageLayoutToolbar() {
         }
       }
 
-      const input = {
+      const input: Record<string, any> = {
         sections: sections as any,
-        theme: themeValuesToPageTheme(themeState) as any,
       };
+
+      // Only persist the theme when the user has explicitly changed it
+      if (isThemeDirty) {
+        input.theme = themeValuesToPageTheme(themeState) as any;
+      }
 
       if (state.pageConfigId) {
         await updatePageConfig({
@@ -221,6 +225,8 @@ function ManageLayoutToolbar() {
         variables: {
           input: {
             ...input,
+            // Always include theme on first creation so the page config has an initial value
+            theme: themeValuesToPageTheme(themeState) as any,
             name: (state.data as Event | Space)?.title || 'Page Config',
             owner_id: state.data?._id,
             owner_type: state.layoutType === 'event' ? PageConfigOwnerType.Event : PageConfigOwnerType.Space,

--- a/lib/components/features/ai/manage/craft/CraftableEventSections.tsx
+++ b/lib/components/features/ai/manage/craft/CraftableEventSections.tsx
@@ -10,7 +10,9 @@ export function CraftableEventSections({ data }: { data?: Record<string, any> })
   const [ready, setReady] = React.useState(false);
 
   React.useEffect(() => {
-    actions.deserialize(JSON.stringify(data));
+    if (data !== undefined) {
+      actions.deserialize(JSON.stringify(data));
+    }
     setReady(true);
   }, []);
 

--- a/lib/components/features/ai/manage/craft/resolver.tsx
+++ b/lib/components/features/ai/manage/craft/resolver.tsx
@@ -495,6 +495,7 @@ export const CraftSection = ({
   const { index, total, parentId } = getPosition();
   const isFirst = index === 0;
   const isLast = index === total - 1;
+  const parentIsInlineGrid = !!parentId && nodes[parentId]?.type?.resolvedName === 'InlineGrid';
 
   const moveUp = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -559,6 +560,18 @@ export const CraftSection = ({
           if (!curParent) return;
 
           if (zone === 'top' || zone === 'bottom') {
+            // When dropping at the bottom of a section that is a direct child of an InlineGrid,
+            // wrap it and the dragged section in a new Col — producing a stacked column layout.
+            const parentIsInlineGrid = nodes[curParent]?.type?.resolvedName === 'InlineGrid';
+            if (zone === 'bottom' && parentIsInlineGrid) {
+              if (source.data.type === 'canvas-node') {
+                actions.wrapInColStack(id, source.data.nodeId as string);
+              } else if (source.data.type === 'new-section') {
+                const { componentName, displayName } = source.data as any;
+                actions.wrapNewInColStack(id, componentName, displayName);
+              }
+              return;
+            }
             const targetIndex = zone === 'top' ? curIndex : curIndex + 1;
             if (source.data.type === 'canvas-node') {
               actions.moveNode(source.data.nodeId as string, curParent, targetIndex);
@@ -621,7 +634,13 @@ export const CraftSection = ({
         <div className="absolute -top-0.5 left-2 right-2 h-0.5 bg-accent-400 z-[110] rounded-full pointer-events-none" />
       )}
       {dragZone === 'bottom' && enabled && (
-        <div className="absolute -bottom-0.5 left-2 right-2 h-0.5 bg-accent-400 z-[110] rounded-full pointer-events-none" />
+        parentIsInlineGrid ? (
+          <div className="absolute inset-0 border-2 border-accent-400 bg-accent-400/10 z-[110] rounded-2xl pointer-events-none flex items-center justify-center">
+            <span className="bg-accent-500 text-white text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wide">Stack</span>
+          </div>
+        ) : (
+          <div className="absolute -bottom-0.5 left-2 right-2 h-0.5 bg-accent-400 z-[110] rounded-full pointer-events-none" />
+        )
       )}
       {dragZone === 'inline' && enabled && (
         <div className="absolute inset-0 border-2 border-accent-400 bg-accent-400/10 z-[110] rounded-2xl pointer-events-none flex items-center justify-center">
@@ -1200,7 +1219,26 @@ export const Container = ({
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [containerDropActive, setContainerDropActive] = React.useState(false);
 
-  // ... (useEffect for DnD)
+  React.useEffect(() => {
+    if (!enabled || !containerRef.current) return;
+    return dropTargetForElements({
+      element: containerRef.current,
+      canDrop: ({ source }) => source.data.type === 'canvas-node' || source.data.type === 'new-section',
+      onDragEnter: () => setContainerDropActive(true),
+      onDragLeave: () => setContainerDropActive(false),
+      onDrop: ({ source, location }) => {
+        setContainerDropActive(false);
+        // Only handle drops that land directly on this Container (not on a child)
+        if (location.current.dropTargets[0]?.element !== containerRef.current) return;
+        if (source.data.type === 'canvas-node') {
+          actions.moveNode(source.data.nodeId as string, id, Number.MAX_SAFE_INTEGER);
+        } else if (source.data.type === 'new-section') {
+          const { componentName, displayName } = source.data as any;
+          actions.addNode(id, componentName, displayName, {});
+        }
+      },
+    });
+  }, [enabled, id]);
 
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions

--- a/lib/components/features/event/EventGuestSide.tsx
+++ b/lib/components/features/event/EventGuestSide.tsx
@@ -185,8 +185,8 @@ export function EventGuestSideContent({
   };
 
   const renderContent = () => {
-    if (isEditable && isClient && event && formattedStructureData) {
-      return <CraftableEventSections data={formattedStructureData} />;
+    if (isEditable && isClient && event) {
+      return <CraftableEventSections data={formattedStructureData ?? undefined} />;
     }
 
     if (formattedStructureData && isClient) {

--- a/lib/components/features/page-builder/context.tsx
+++ b/lib/components/features/page-builder/context.tsx
@@ -36,6 +36,8 @@ type PageEditorAction =
   | { type: 'ADD'; parentId: string; nodeId: string; node: NodeRecord; index: number }
   | { type: 'WRAP_IN_INLINE_GRID'; targetNodeId: string; sourceNodeId: string }
   | { type: 'WRAP_NEW_IN_INLINE_GRID'; targetNodeId: string; newNodeId: string; newNode: NodeRecord }
+  | { type: 'WRAP_IN_COL_STACK'; targetNodeId: string; sourceNodeId: string }
+  | { type: 'WRAP_NEW_IN_COL_STACK'; targetNodeId: string; newNodeId: string; newNode: NodeRecord }
   | { type: 'UNDO' }
   | { type: 'REDO' }
   | { type: 'CLEAR_HISTORY' };
@@ -229,6 +231,80 @@ function reducer(state: PageEditorState, action: PageEditorAction): PageEditorSt
       return { ...state, nodes, past: [...state.past.slice(-MAX_HISTORY + 1), state.nodes], future: [] };
     }
 
+    case 'WRAP_IN_COL_STACK': {
+      // Wraps the target node and source node together in a new Col inside the parent InlineGrid.
+      // Produces: InlineGrid → [..., Col[target, source], ...]
+      const { targetNodeId, sourceNodeId } = action;
+      const targetNode = state.nodes[targetNodeId];
+      const sourceNode = state.nodes[sourceNodeId];
+      if (!targetNode || !sourceNode) return state;
+
+      const parentId = targetNode.parent;
+      if (!parentId || !state.nodes[parentId]) return state;
+
+      const colId = genId();
+      const nodes = { ...state.nodes };
+
+      const sourceParentId = sourceNode.parent;
+      if (sourceParentId && nodes[sourceParentId]) {
+        nodes[sourceParentId] = {
+          ...nodes[sourceParentId],
+          nodes: nodes[sourceParentId].nodes.filter((id) => id !== sourceNodeId),
+        };
+      }
+
+      nodes[colId] = {
+        type: { resolvedName: 'Col' },
+        isCanvas: true,
+        props: {},
+        nodes: [targetNodeId, sourceNodeId],
+        linkedNodes: {},
+        parent: parentId,
+        displayName: 'Column',
+        custom: {},
+      };
+      nodes[parentId] = {
+        ...nodes[parentId],
+        nodes: nodes[parentId].nodes.map((id) => (id === targetNodeId ? colId : id)),
+      };
+      nodes[targetNodeId] = { ...nodes[targetNodeId], parent: colId };
+      nodes[sourceNodeId] = { ...nodes[sourceNodeId], parent: colId };
+
+      return { ...state, nodes, past: [...state.past.slice(-MAX_HISTORY + 1), state.nodes], future: [] };
+    }
+
+    case 'WRAP_NEW_IN_COL_STACK': {
+      const { targetNodeId, newNodeId, newNode } = action;
+      const targetNode = state.nodes[targetNodeId];
+      if (!targetNode) return state;
+
+      const parentId = targetNode.parent;
+      if (!parentId || !state.nodes[parentId]) return state;
+
+      const colId = genId();
+      const nodes = {
+        ...state.nodes,
+        [colId]: {
+          type: { resolvedName: 'Col' },
+          isCanvas: true,
+          props: {},
+          nodes: [targetNodeId, newNodeId],
+          linkedNodes: {},
+          parent: parentId,
+          displayName: 'Column',
+          custom: {},
+        } as NodeRecord,
+        [parentId]: {
+          ...state.nodes[parentId],
+          nodes: state.nodes[parentId].nodes.map((id) => (id === targetNodeId ? colId : id)),
+        },
+        [targetNodeId]: { ...targetNode, parent: colId },
+        [newNodeId]: { ...newNode, parent: colId },
+      };
+
+      return { ...state, nodes, past: [...state.past.slice(-MAX_HISTORY + 1), state.nodes], future: [] };
+    }
+
     case 'UNDO': {
       if (state.past.length === 0) return state;
       const prev = state.past[state.past.length - 1];
@@ -285,6 +361,8 @@ export interface PageEditorContextValue {
     ) => string;
     wrapInInlineGrid: (targetNodeId: string, sourceNodeId: string) => void;
     wrapNewInInlineGrid: (targetNodeId: string, componentName: string, displayName: string, props?: Record<string, any>) => void;
+    wrapInColStack: (targetNodeId: string, sourceNodeId: string) => void;
+    wrapNewInColStack: (targetNodeId: string, componentName: string, displayName: string, props?: Record<string, any>) => void;
     undo: () => void;
     redo: () => void;
     clearHistory: () => void;
@@ -457,6 +535,30 @@ export function PageEditorProvider({
     [],
   );
 
+  const wrapInColStack = React.useCallback(
+    (targetNodeId: string, sourceNodeId: string) =>
+      dispatch({ type: 'WRAP_IN_COL_STACK', targetNodeId, sourceNodeId }),
+    [],
+  );
+
+  const wrapNewInColStack = React.useCallback(
+    (targetNodeId: string, componentName: string, displayName: string, props: Record<string, any> = {}): void => {
+      const newNodeId = genId();
+      const newNode: NodeRecord = {
+        type: { resolvedName: componentName },
+        isCanvas: CANVAS_COMPONENTS.has(componentName),
+        props,
+        nodes: [],
+        linkedNodes: {},
+        parent: '',
+        displayName,
+        custom: {},
+      };
+      dispatch({ type: 'WRAP_NEW_IN_COL_STACK', targetNodeId, newNodeId, newNode });
+    },
+    [],
+  );
+
   const wrapNewInInlineGrid = React.useCallback(
     (targetNodeId: string, componentName: string, displayName: string, props: Record<string, any> = {}): void => {
       const newNodeId = genId();
@@ -499,6 +601,8 @@ export function PageEditorProvider({
         addNode,
         wrapInInlineGrid,
         wrapNewInInlineGrid,
+        wrapInColStack,
+        wrapNewInColStack,
         undo,
         redo,
         clearHistory,

--- a/lib/utils/page-theme-adapter.ts
+++ b/lib/utils/page-theme-adapter.ts
@@ -35,9 +35,7 @@ export function themeValuesToPageTheme(data: ThemeValues): StoredPageTheme {
     mode: config.mode ?? 'dark',
   };
 
-  if (config.color) {
-    theme.colors = { accent: config.color };
-  }
+  theme.colors = { accent: config.color || 'woodsmoke' };
 
   // Background: shader or pattern uses config.name; image uses config.image.url
   if (preset === 'shader' && config.name) {


### PR DESCRIPTION
## Summary

- Fix loading race condition where `loadingPageConfig` initialises to `false` before the fetch begins, causing a blank flash in the editor
- Apply `DEFAULT_EVENT_SECTIONS` as fallback when no saved page config exists for events
- Guard `CraftableEventSections` against calling `deserialize` with `undefined` data
- Implement `Container` drop target so sections can be dragged into the container area below the grid
- Add col-stack drag interaction: dropping a section on the **bottom zone** of a section inside an InlineGrid wraps them in a `Col`, producing a row-span layout (section 1 spans height, section 2 + 3 stack in column 2)
- Show **"Stack"** overlay indicator on the bottom drop zone when inside an InlineGrid
- Only include theme in `updatePageConfig` payload when the user has explicitly changed it (`isThemeDirty`), preventing accidental theme overwrites on layout save
- Default `colors.accent` to `woodsmoke` in `themeValuesToPageTheme` when no color is set

## Test plan

- [ ] Open a new event in page builder — default sections load without blank flash
- [ ] Drag two sections together → InlineGrid (Side by side) forms
- [ ] Drag a third section to the **bottom 25%** of a column in InlineGrid → "Stack" overlay appears → creates `Col[section2, section3]` stacked next to section1
- [ ] Drag a section to the **middle** of an InlineGrid column → still adds as a new column
- [ ] Drag a section to the empty container area below the grid → section appends after the grid
- [ ] Save layout without changing theme → theme is NOT overwritten on the backend
- [ ] New page config created for first time → `colors.accent` defaults to `woodsmoke`
- [ ] Undo/redo works for all new drag actions

> **Note:** `inline_grid` needs to be added to the backend `SectionType` enum before the col-stack save will work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)