### PR TITLE
fix: community preview theme scoping

### DIFF
--- a/__tests__/components/community-manage-preview.test.tsx
+++ b/__tests__/components/community-manage-preview.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import CommunityManagePreview from '$lib/components/features/community-manage/CommunityManagePreview';
+import { Space } from '$lib/graphql/generated/backend/graphql';
+import { ThemeValues } from '$lib/components/features/theme-builder/store';
+
+const themeGeneratorSpy = vi.fn();
+
+vi.mock('$lib/components/features/community', () => ({
+  Community: () => <div data-testid="community-component" />,
+}));
+
+vi.mock('$lib/components/features/theme-builder/generator', () => ({
+  ThemeGenerator: (props: any) => {
+    themeGeneratorSpy(props);
+    return <div data-testid="theme-generator" />;
+  },
+}));
+
+vi.mock('$lib/components/features/theme-builder/provider', () => ({
+  ThemeProvider: ({ children }: any) => <>{children}</>,
+}));
+
+const mockSpace = {
+  _id: 'space-1',
+  title: 'Preview Community',
+  slug: 'preview-community',
+} as Space;
+
+const mockTheme = {
+  theme: 'shader',
+  config: {
+    mode: 'dark',
+    color: 'violet',
+    name: 'dreamy',
+    class: '',
+    effect: {
+      name: '',
+      url: '',
+      emoji: '',
+    },
+  },
+  font_title: 'default',
+  font_body: 'default',
+  variables: {
+    font: {
+      '--font-title': 'var(--font-class-display)',
+      '--font-body': 'var(--font-general-sans)',
+    },
+    custom: {},
+    dark: {},
+    light: {},
+    pattern: {},
+  },
+} satisfies ThemeValues;
+
+describe('CommunityManagePreview', () => {
+  afterEach(() => {
+    cleanup();
+    themeGeneratorSpy.mockClear();
+  });
+
+  it('scopes the theme to the preview surface and keeps community content inside the page wrapper', () => {
+    const { container } = render(<CommunityManagePreview space={mockSpace} themeData={mockTheme} />);
+
+    const main = container.querySelector('main');
+    const pageWrapper = main?.querySelector('.page');
+
+    expect(main).toBeTruthy();
+    expect(main?.getAttribute('data-theme-scope')).toBe('community-preview');
+    expect(main?.getAttribute('data-theme')).toBe('dark');
+    expect(main?.className).toContain('shader');
+    expect(main?.className).toContain('dreamy');
+    expect(main?.className).toContain('violet');
+    expect(main?.className).toContain('dark');
+    expect(pageWrapper).toBeTruthy();
+    expect(pageWrapper?.contains(screen.getByTestId('community-component'))).toBe(true);
+    expect(main?.contains(screen.getByTestId('community-component'))).toBe(true);
+    expect(themeGeneratorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: mockTheme,
+        scoped: true,
+        scopeSelector: "[data-theme-scope='community-preview']",
+      }),
+    );
+  });
+});

--- a/lib/components/features/community-manage/CommunityManagePreview.tsx
+++ b/lib/components/features/community-manage/CommunityManagePreview.tsx
@@ -17,23 +17,28 @@ export default function CommunityManagePreview({
   themeData: ThemeValues;
 }) {
   const providerKey = React.useMemo(() => `${space._id}:${JSON.stringify(themeData)}`, [space._id, themeData]);
+  const mode = themeData.config.mode;
 
   return (
     <main
       data-theme-scope="community-preview"
+      data-theme={mode === 'auto' ? undefined : mode}
       className={clsx(
-        'relative isolate flex min-h-full w-full flex-col',
+        'relative isolate flex w-full min-h-full flex-col overflow-hidden bg-background rounded-none md:rounded-md',
         themeData.theme,
         themeData.config.name,
         themeData.config.color,
-        themeData.config.mode,
+        mode === 'light' && 'light',
+        mode === 'dark' && 'dark',
       )}
-      style={themeData.variables.font as React.CSSProperties}
+      style={{ ...themeData.variables.font, position: 'relative' } as React.CSSProperties}
     >
       <ThemeGenerator data={themeData} scoped scopeSelector="[data-theme-scope='community-preview']" />
       <ThemeProvider key={providerKey} themeData={themeData}>
-        <div className="page relative z-10 mx-auto px-4 pt-6 pb-20 xl:px-0">
-          <Community initData={{ space }} hideManageControls />
+        <div className="relative z-10 flex w-full flex-1">
+          <div className="page mx-auto w-full px-4 pt-6 pb-20 xl:px-0">
+            <Community initData={{ space }} hideManageControls />
+          </div>
         </div>
       </ThemeProvider>
     </main>


### PR DESCRIPTION
## What
- Updated the community manage preview to use the same themed preview surface structure as the working event theme preview.
- Scoped community theme classes and `data-theme` attributes to the preview `main` surface instead of letting the theme bleed into the broader manage layout.
- Kept community content inside the centered `.page` wrapper while clipping the themed surface with `overflow-hidden`.
- Added a regression test for `CommunityManagePreview` to verify the preview surface/theme boundary and inner page wrapper structure.

## Why
- The community design preview applied gradient and pattern themes across the full manage screen instead of only the community preview.
- Matching the event preview structure fixes the visual bleed and makes community theme behavior consistent across builders.
- The regression test reduces the chance of reintroducing scope/layout issues in future theme preview changes.

## How
- Moved the community preview to an event-style structure with:
  - `data-theme-scope="community-preview"` on the preview `main`
  - explicit `data-theme`, `light`, and `dark` handling from `themeData.config.mode`
  - `overflow-hidden` on the preview surface to clip shader/pattern backgrounds
- Kept `ThemeGenerator` scoped to `[data-theme-scope='community-preview']`.
- Left the community content centered inside an inner `.page` container so layout width stays unchanged while the preview surface fills correctly.
- Added a focused Vitest test that asserts the preview surface attributes/classes and confirms the community content remains inside the inner page wrapper.

## Designs
- Based on the provided before/after screenshots comparing the broken community preview against the working event theme preview.

## Test Steps
- [ ] Go to `/s/manage/:uid` and open the `Design` tab.
- [ ] Select the `Gradient` theme in the left pane.
- [ ] Verify the gradient is clipped to the community preview surface only.
- [ ] Verify the left design pane and surrounding manage shell stay neutral and are not covered by the theme.
- [ ] Switch between `Light`, `Dark`, and `Auto` display modes and confirm the preview still stays scoped correctly.
- [ ] Select the `Pattern` theme and confirm it is also clipped to the preview surface.
- [ ] Run `yarn vitest run __tests__/components/community-manage-preview.test.tsx`.
- [ ] Run `yarn vitest run __tests__/components/settings-community-display.test.tsx`.

## Other Notes
- The fix was derived by matching the working event preview structure instead of inventing a separate community-specific preview pattern.
