### PR TITLE
fix: reduce manage layout bottom spacing

### DIFF
--- a/lib/components/features/ai/manage/ManageLayoutContent.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutContent.tsx
@@ -345,7 +345,7 @@ function ManageLayoutContent({
         )}
       </AnimatePresence>
 
-      <div className="hidden md:flex px-0 flex-1 overflow-hidden pb-10">
+      <div className="hidden md:flex px-0 flex-1 overflow-hidden pb-3">
         <AnimatePresence initial={false}>
           {state.showSidebarLeft && (
             <motion.div


### PR DESCRIPTION
## What
- Reduced the desktop bottom spacing in the shared manage layout container.
- Aligned the bottom inset with the top spacing for the manage view.

## Why
- The manage layout had visibly more space at the bottom than the top.
- This makes the frame feel more balanced and closer to the intended UI.

## How
- Updated the desktop wrapper in `ManageLayoutContent.tsx`.
- Changed the bottom padding from `pb-10` to `pb-3`.

## Designs
- N/A

## Test Steps
- [ ] Open a manage page on desktop.
- [ ] Compare the top and bottom spacing around the main manage container.
- [ ] Confirm the bottom space matches the top more closely than before.

## Other Notes
- [ ] Not run locally; change is a small CSS spacing adjustment only.
