### PR TITLE
fix: insights time filter to 6 months

### DIFF
--- a/lib/components/features/community-manage/CommunityInsightsOverview.tsx
+++ b/lib/components/features/community-manage/CommunityInsightsOverview.tsx
@@ -30,14 +30,14 @@ import {
 import { useQuery } from '$lib/graphql/request';
 import { userAvatar } from '$lib/utils/user';
 
-type SubscriberRange = '1H' | '1D' | '1W' | '1M' | '1Y' | 'All';
+type SubscriberRange = '1D' | '1W' | '1M' | '6M' | '1Y' | 'All';
 
 type HostRow = GetTopSpaceHostsQuery['getTopSpaceHosts'][number];
 type AttendeeRow = GetTopSpaceEventAttendeesQuery['getTopSpaceEventAttendees'][number];
 type LocationRow = GetSpaceEventLocationsLeaderboardQuery['getSpaceEventLocationsLeaderboard'][number];
 type SubscriberPoint = GetSpaceMemberAmountByDateQuery['getSpaceMemberAmountByDate'][number];
 
-const SUBSCRIBER_RANGES: readonly SubscriberRange[] = ['1H', '1D', '1W', '1M', '1Y', 'All'];
+const SUBSCRIBER_RANGES: readonly SubscriberRange[] = ['1D', '1W', '1M', '6M', '1Y', 'All'];
 const LEADERBOARD_LIMIT = 5;
 const HOST_SUMMARY_LIMIT = 1000;
 const LOCATION_LIMIT = 5;
@@ -518,8 +518,8 @@ function getSubscriberRangeWindow(range: SubscriberRange) {
   const start = new Date(end);
 
   switch (range) {
-    case '1H':
-      start.setHours(start.getHours() - 1);
+    case '6M':
+      start.setMonth(start.getMonth() - 6);
       break;
     case '1D':
       start.setDate(start.getDate() - 1);
@@ -546,8 +546,8 @@ function formatSubscriberTooltipLabel(value: string, range: SubscriberRange) {
   if (Number.isNaN(date.getTime())) return value;
 
   switch (range) {
-    case '1H':
-      return format(date, 'MMM d, h:mm a');
+    case '6M':
+      return format(date, 'MMM d, yyyy');
     case '1D':
       return format(date, 'MMM d, h:mm a');
     case '1W':

--- a/lib/utils/chart.ts
+++ b/lib/utils/chart.ts
@@ -3,9 +3,9 @@ import { format } from 'date-fns';
 
 import { Event } from '$lib/graphql/generated/backend/graphql';
 
-export type TimeRange = '1H' | '1D' | '1W' | '1M' | 'All';
+export type TimeRange = '1D' | '1W' | '1M' | '6M' | 'All';
 
-export const TIME_RANGES: TimeRange[] = ['1H', '1D', '1W', '1M', 'All'];
+export const TIME_RANGES: TimeRange[] = ['1D', '1W', '1M', '6M', 'All'];
 
 export function useTimeRange(event: Event | null | undefined, selectedRange: TimeRange) {
   return useMemo(() => {
@@ -25,8 +25,9 @@ export function useTimeRange(event: Event | null | undefined, selectedRange: Tim
     let calculatedStartTime: Date;
 
     switch (selectedRange) {
-      case '1H':
-        calculatedStartTime = new Date(calculatedEndTime.getTime() - 60 * 60 * 1000);
+      case '6M':
+        calculatedStartTime = new Date(calculatedEndTime);
+        calculatedStartTime.setMonth(calculatedStartTime.getMonth() - 6);
         break;
       case '1D':
         calculatedStartTime = new Date(calculatedEndTime.getTime() - 24 * 60 * 60 * 1000);
@@ -60,14 +61,13 @@ export function getIntervalKey(date: Date, range: TimeRange): string {
   const minute = date.getMinutes();
 
   switch (range) {
-    case '1H':
-      return new Date(year, month, day, hour, minute).toISOString();
-    case '1D':
-      return new Date(year, month, day, hour).toISOString();
-    case '1W':
+    case '6M':
     case '1M':
+    case '1W':
     case 'All':
       return new Date(year, month, day).toISOString();
+    case '1D':
+      return new Date(year, month, day, hour).toISOString();
     default:
       return new Date(year, month, day, hour).toISOString();
   }
@@ -102,8 +102,8 @@ export function formatTooltipLabel(timeValue: string, range: TimeRange): string 
   const date = new Date(timeValue);
 
   switch (range) {
-    case '1H':
-      return format(date, 'h:mm');
+    case '6M':
+      return format(date, 'MMM d, yyyy');
     case '1D':
       return format(date, 'MMM d, h:mm a');
     case '1W':
@@ -117,8 +117,8 @@ export function formatTooltipLabel(timeValue: string, range: TimeRange): string 
 
 export function getIntervalLabel(range: TimeRange): string {
   switch (range) {
-    case '1H':
-      return 'M';
+    case '6M':
+      return 'D';
     case '1D':
       return 'H';
     case '1W':
@@ -129,4 +129,3 @@ export function getIntervalLabel(range: TimeRange): string {
       return 'H';
   }
 }
-


### PR DESCRIPTION
## What
- Replaced the `1H` insights time filter with `6M`.
- Reordered insights filter options to `1D`, `1W`, `1M`, `6M`, `All` in shared event insights.
- Updated community insights filter options to `1D`, `1W`, `1M`, `6M`, `1Y`, `All`.

## Why
- Align the insights filter with the requested six-month view.
- Keep the range selector in a more natural chronological order.

## How
- Updated shared chart time range types and filter arrays in `lib/utils/chart.ts`.
- Changed the range window logic from one hour to six months and adjusted grouping/tooltip formatting for the longer range.
- Updated community insights range definitions and six-month date window handling in `lib/components/features/community-manage/CommunityInsightsOverview.tsx`.

## Designs
- N/A

## Test Steps
- [ ] Open event insights and confirm the filter shows `1D`, `1W`, `1M`, `6M`, `All`.
- [ ] Select `6M` in event insights and confirm chart data loads with date-based labels.
- [ ] Open community insights and confirm the filter shows `1D`, `1W`, `1M`, `6M`, `1Y`, `All`.
- [ ] Select `6M` in community insights and confirm the data reflects a six-month window.

## Other Notes
- [ ] Assumption: the requested change applies to both shared event insights and community insights.
- [ ] Full typecheck was not completed in this pass because the repo helper requires explicit `--base` and `--head` refs.
