### PR TITLE
feat: support custom AI page builder CSS

### DIFF
--- a/app/api/page-builder/theme-catalog/route.ts
+++ b/app/api/page-builder/theme-catalog/route.ts
@@ -9,6 +9,7 @@ export async function GET() {
       { value: 'shader', name: 'Gradient', description: 'Animated gradient background' },
       { value: 'pattern', name: 'Pattern', description: 'Repeating geometric background pattern' },
       { value: 'image', name: 'Image', description: 'Custom background image' },
+      { value: 'custom', name: 'Custom', description: 'Custom CSS variables and page-scoped CSS for bespoke styling' },
     ],
     modes: [
       { value: 'dark', name: 'Dark' },

--- a/lib/components/features/ai/InputChat.tsx
+++ b/lib/components/features/ai/InputChat.tsx
@@ -110,9 +110,14 @@ export function InputChat({
 
     // New format: { sections: [...], theme: {...} }
     if (payload && typeof payload === 'object' && !Array.isArray(payload) && 'sections' in payload) {
-      const { sections, theme } = payload as { sections: unknown[]; theme?: Record<string, unknown> };
+      const { sections, theme, custom_code } = payload as {
+        sections: unknown[];
+        theme?: Record<string, unknown>;
+        custom_code?: Record<string, unknown>;
+      };
       triggers.applySections(sections as any);
       if (theme) triggers.applyTheme(theme);
+      triggers.applyCustomCode(custom_code);
     } else if (Array.isArray(payload)) {
       // Bare sections array (backward compat)
       triggers.applySections(payload as any);
@@ -271,9 +276,12 @@ export function InputChat({
     if (!text) {
       return;
     }
+    const pageEditTriggers = getAIPageEditTriggers();
     const runData = {
       ...((state.data as Record<string, unknown> | undefined) || {}),
       ...(fixedSpaceId ? { space_id: fixedSpaceId } : {}),
+      ...(state.pageConfig ? { page_config_id: (state.pageConfig as any)._id } : {}),
+      ...(pageEditTriggers ? { page_sections: pageEditTriggers.getSections() } : {}),
     };
 
     dispatch({ type: AIChatActionKind.add_message, payload: { messages: [{ message: text, role: 'user' }] } });

--- a/lib/components/features/ai/manage/ManageLayout.tsx
+++ b/lib/components/features/ai/manage/ManageLayout.tsx
@@ -16,9 +16,7 @@ import { EventThemeProvider } from '$lib/components/features/theme-builder/provi
 import {
   Event,
   GetEventDocument,
-  GetPageConfigDocument,
   GetSpaceDocument,
-  PageConfigFragmentFragmentDoc,
   PageConfigOwnerType,
   Space,
 } from '$lib/graphql/generated/backend/graphql';
@@ -31,8 +29,8 @@ import { getCommunityThemeData } from '../../community-manage/theme';
 import { PageEditorProvider } from '$lib/components/features/page-builder/context';
 import { useParams } from 'next/navigation';
 import { useQuery } from '$lib/graphql/request';
+import { GetPageConfigWithCustomCodeDocument } from '$lib/graphql/custom/page-config';
 import { pageThemeToThemeValues, type StoredPageTheme } from '$utils/page-theme-adapter';
-import { useFragment } from '$lib/graphql/generated/backend/fragment-masking';
 
 interface Props extends React.PropsWithChildren {
   layoutType?: LayoutType;
@@ -79,7 +77,7 @@ function ManageLayout({
   });
 
   const pageConfigShouldFetch = !!state.data?._id && !state.pageConfigId;
-  const { data: pageConfigRaw, loading: loadingPageConfig, error: pageConfigError } = useQuery(GetPageConfigDocument, {
+  const { data: pageConfigRaw, loading: loadingPageConfig, error: pageConfigError } = useQuery(GetPageConfigWithCustomCodeDocument, {
     variables: {
       ownerType: state.layoutType === 'event' ? PageConfigOwnerType.Event : PageConfigOwnerType.Space,
       ownerId: state.data?._id,
@@ -87,12 +85,14 @@ function ManageLayout({
     skip: !pageConfigShouldFetch,
   });
 
-  const pageConfigFields = useFragment(PageConfigFragmentFragmentDoc, pageConfigRaw?.getPageConfig);
+  const pageConfigFields = pageConfigRaw?.getPageConfig;
 
   React.useEffect(() => {
     if (pageConfigFields?._id) {
       storeManageLayout.setPageConfigId(pageConfigFields._id);
       storeManageLayout.setSavedPageTheme(pageConfigFields.theme || undefined);
+      storeManageLayout.setSavedPageCustomCode(pageConfigFields.custom_code || undefined);
+      storeManageLayout.setPageCustomCode(pageConfigFields.custom_code || undefined);
     }
   }, [pageConfigFields]);
 

--- a/lib/components/features/ai/manage/ManageLayoutContent.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutContent.tsx
@@ -12,12 +12,8 @@ import { aiChatClient } from '$lib/graphql/request/instances';
 import {
   Event,
   GetEventDocument,
-  GetPageConfigDocument,
-  PageConfigFragmentFragmentDoc,
-  PageConfigOwnerType,
   Space,
 } from '$lib/graphql/generated/backend/graphql';
-import { useFragment } from '$lib/graphql/generated/backend/fragment-masking';
 import { EventGuestSide } from '$lib/components/features/event/EventGuestSide';
 import { ThemeGenerator } from '$lib/components/features/theme-builder/generator';
 import { ThemeBuilderActionKind, useEventTheme } from '$lib/components/features/theme-builder/provider';
@@ -30,10 +26,16 @@ import ManageCommunityLayout from '../../community-manage/ManageCommunityLayout'
 import CommunityManageDesignPane from '../../community-manage/CommunityManageDesignPane';
 import CommunityManagePreview from '../../community-manage/CommunityManagePreview';
 
-import { storeManageLayout as store, useStoreManageLayout } from './store';
+import { type PageCustomCode, storeManageLayout as store, useStoreManageLayout } from './store';
 import { usePageEditor } from '$lib/components/features/page-builder/context';
 import { setAIPageEditTriggers } from '$lib/components/features/page-builder/hooks/ai-page-edit-bridge';
-import { sectionsToNodes, nodesToSections, sectionToNodePatch, type PageSection } from '$utils/page-sections-mapper';
+import {
+  sectionsToNodes,
+  nodesToSections,
+  resolveSectionTypeToResolvedName,
+  sectionToNodePatch,
+  type PageSection,
+} from '$utils/page-sections-mapper';
 import { pageThemeToThemeValues, type StoredPageTheme } from '$utils/page-theme-adapter';
 import { SettingsPanel } from './SettingsPanel';
 
@@ -77,7 +79,7 @@ function ManageLayoutContent({
   const [_, aiChatDispatch] = useAIChat();
   const initializedConfigEventRef = React.useRef<string | null>(null);
 
-  const { selectedId, actions, query } = usePageEditor();
+  const { nodes, selectedId, actions, query } = usePageEditor();
   const isSelected = selectedId !== null;
 
   const cachedEvent = state.data as Event | undefined;
@@ -92,7 +94,7 @@ function ManageLayoutContent({
     (dataGetEvent?.getEvent as Event | undefined) || (cachedEvent?.shortid === shortid ? cachedEvent : undefined);
   const eventId = event?._id;
 
-  const pageConfigData_ = useFragment(PageConfigFragmentFragmentDoc, pageConfigProp);
+  const pageConfigData_ = pageConfigProp;
 
   React.useEffect(() => {
     if (pageConfigProp) {
@@ -216,8 +218,8 @@ function ManageLayoutContent({
     ))
     .otherwise(() => null);
 
-  const editorRef = React.useRef({ actions, query, state });
-  editorRef.current = { actions, query, state };
+  const editorRef = React.useRef({ actions, query, state, nodes });
+  editorRef.current = { actions, query, state, nodes };
 
   const themeDispatchRef = React.useRef(themeDispatch);
   themeDispatchRef.current = themeDispatch;
@@ -232,23 +234,34 @@ function ManageLayoutContent({
         editorRef.current.actions.deserialize(JSON.stringify(nodes));
       },
       applySectionUpdate: (section: PageSection) => {
-        const { actions, query } = editorRef.current;
-        const { nodeId, props } = sectionToNodePatch(section);
-        try {
-          query.node(nodeId).get();
-          actions.setProp(nodeId, (p: Record<string, unknown>) => Object.assign(p, props));
-        } catch {
-          // Node doesn't exist — inject at end of main-col
-          const nodes = sectionsToNodes([section]);
-          const newNode = nodes[nodeId];
-          if (newNode && query.node('main-col').get()) {
-            actions.addNode('main-col', newNode.type.resolvedName, newNode.displayName, newNode.props);
-          }
+        const { actions, nodes } = editorRef.current;
+        const { nodeId, props, resolvedName } = sectionToNodePatch(section);
+        const existingNodeId =
+          (nodes[nodeId] ? nodeId : null) ||
+          Object.entries(nodes).find(([id, node]) => {
+            if (id === 'ROOT') return false;
+            return node.type.resolvedName === resolveSectionTypeToResolvedName(section.type);
+          })?.[0];
+
+        if (existingNodeId) {
+          actions.setProp(existingNodeId, (p: Record<string, unknown>) => Object.assign(p, props));
+          return;
+        }
+
+        // Node doesn't exist — inject at end of the main column when present.
+        const nextNodes = sectionsToNodes([section]);
+        const newNode = nextNodes[nodeId];
+        const parentId = nodes['main-col'] ? 'main-col' : 'ROOT';
+        if (newNode && nodes[parentId]) {
+          actions.addNode(parentId, resolvedName, newNode.displayName, newNode.props, section.order);
         }
       },
       applyTheme: (theme: Record<string, unknown>) => {
         const themeValues = pageThemeToThemeValues(theme as StoredPageTheme);
         themeDispatchRef.current({ type: ThemeBuilderActionKind.reset, payload: themeValues });
+      },
+      applyCustomCode: (customCode: Record<string, unknown> | undefined) => {
+        store.setPageCustomCode(customCode as PageCustomCode | undefined);
       },
       getSections: () => {
         try {
@@ -296,6 +309,7 @@ function ManageLayoutContent({
       event ? (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events -- clicking empty canvas background to deselect nodes is a mouse-only affordance; keyboard users deselect via Escape handled elsewhere
         <main
+          data-page-theme-root
           data-theme-scope="event-preview"
           data-theme={themeState.config.mode === 'auto' ? undefined : themeState.config.mode}
           className={clsx(
@@ -309,6 +323,7 @@ function ManageLayoutContent({
             if (e.target === e.currentTarget) actions.selectNode(null);
           }}
         >
+          {state.pageCustomCode?.css ? <style dangerouslySetInnerHTML={{ __html: state.pageCustomCode.css }} /> : null}
           <ThemeGenerator data={themeState} scoped scopeSelector="[data-theme-scope='event-preview']" />
           {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- background click to deselect node; non-interactive container */}
           <div

--- a/lib/components/features/ai/manage/ManageLayoutToolbar.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutToolbar.tsx
@@ -90,6 +90,7 @@ function ManageLayoutToolbar() {
         toast.success('Theme saved successfully!');
         store.setPageConfigId(pageConfig._id);
         store.setSavedPageTheme(themeValuesToPageTheme(themeState) as Record<string, unknown>);
+        store.setSavedPageCustomCode(state.pageCustomCode);
       }
     },
     onError: (error) => {
@@ -104,6 +105,7 @@ function ManageLayoutToolbar() {
         toast.success('Layout saved successfully!');
         store.setPageConfigId(pageConfig._id);
         store.setSavedPageTheme(pageConfig.theme as Record<string, unknown>);
+        store.setSavedPageCustomCode(state.pageCustomCode);
       }
     },
     onError: (error) => {
@@ -119,6 +121,7 @@ function ManageLayoutToolbar() {
         toast.success('Layout saved successfully!');
         store.setPageConfigId(pageConfig._id);
         store.setSavedPageTheme(pageConfig.theme as Record<string, unknown>);
+        store.setSavedPageCustomCode(state.pageCustomCode);
       }
     },
     onError: (error) => {
@@ -159,7 +162,10 @@ function ManageLayoutToolbar() {
     updatePageConfigTheme({
       variables: {
         id: state.pageConfigId,
-        input: { theme: themeValuesToPageTheme(themeState) as any },
+        input: {
+          theme: themeValuesToPageTheme(themeState) as any,
+          ...(state.pageCustomCode !== undefined ? { custom_code: state.pageCustomCode as any } : {}),
+        },
       },
     });
   };
@@ -209,6 +215,10 @@ function ManageLayoutToolbar() {
       // Only persist the theme when the user has explicitly changed it
       if (isThemeDirty) {
         input.theme = themeValuesToPageTheme(themeState) as any;
+      }
+
+      if (state.pageCustomCode !== undefined) {
+        input.custom_code = state.pageCustomCode as any;
       }
 
       if (state.pageConfigId) {

--- a/lib/components/features/ai/manage/craft/resolver.tsx
+++ b/lib/components/features/ai/manage/craft/resolver.tsx
@@ -1258,6 +1258,8 @@ CraftAccordionItem.craft = {
 
 const ContainerSettings = () => {
   const { id, actions, props } = useSettings();
+  const decorativeImage = props.decorativeImage as Record<string, unknown> | undefined;
+  const decorativeImageSource = getDecorativeImageSource(decorativeImage);
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
@@ -1334,6 +1336,29 @@ const ContainerSettings = () => {
           placeholder="Leave empty for Full Screen"
         />
       </div>
+      {decorativeImageSource ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-card-border bg-card/40 p-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium">Decorative Image</p>
+              <p className="truncate text-xs text-tertiary">{decorativeImageSource}</p>
+            </div>
+            <Button
+              size="xs"
+              variant="tertiary-alt"
+              icon="icon-delete"
+              onClick={() =>
+                actions.setProp((props: any) => {
+                  delete props.decorativeImage;
+                })
+              }
+              className="shrink-0 hover:text-error!"
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/lib/components/features/ai/manage/craft/resolver.tsx
+++ b/lib/components/features/ai/manage/craft/resolver.tsx
@@ -35,6 +35,53 @@ import { uploadFiles } from '$lib/utils/file';
 import { toast } from '$lib/components/core/toast';
 import { usePageEditor, usePageNode, useNodeId } from '$lib/components/features/page-builder/context';
 
+const FALLBACK_BACKGROUND_KEYWORDS: Array<[string, string]> = [
+  ['blue-ocean', 'linear-gradient(135deg, #0ea5e9 0%, #164e63 100%)'],
+  ['ocean', 'linear-gradient(135deg, #0ea5e9 0%, #164e63 100%)'],
+  ['sky', '#38bdf8'],
+  ['blue', '#3b82f6'],
+  ['green', '#22c55e'],
+  ['emerald', '#10b981'],
+  ['teal', '#14b8a6'],
+  ['cyan', '#06b6d4'],
+  ['violet', '#8b5cf6'],
+  ['purple', '#a855f7'],
+  ['pink', '#ec4899'],
+  ['rose', '#f43f5e'],
+  ['red', '#ef4444'],
+  ['orange', '#f97316'],
+  ['yellow', '#eab308'],
+  ['amber', '#f59e0b'],
+  ['white', '#ffffff'],
+  ['black', '#000000'],
+  ['gray', '#6b7280'],
+  ['grey', '#6b7280'],
+];
+
+function normalizeBackgroundValue(background: unknown): string | undefined {
+  const candidate =
+    typeof background === 'string'
+      ? background
+      : background && typeof background === 'object' && 'value' in background && typeof background.value === 'string'
+        ? background.value
+        : undefined;
+
+  if (!candidate) return undefined;
+
+  if (typeof window !== 'undefined' && window.CSS?.supports) {
+    if (window.CSS.supports('background', candidate) || window.CSS.supports('color', candidate)) {
+      return candidate;
+    }
+  }
+
+  const normalized = candidate.trim().toLowerCase();
+  for (const [keyword, value] of FALLBACK_BACKGROUND_KEYWORDS) {
+    if (normalized.includes(keyword)) return value;
+  }
+
+  return undefined;
+}
+
 const useEvent = (props: any) => {
   const layoutState = useStoreManageLayout();
   return (layoutState.data as Event) || props.event;
@@ -520,6 +567,14 @@ export const CraftSection = ({
   const width = nodeProps.width || props.width;
   const height = nodeProps.height || props.height;
   const aspectRatio = nodeProps.aspectRatio || props.aspectRatio;
+  const background =
+    nodeProps.layout_background ||
+    props.layout_background ||
+    nodeProps.background_color ||
+    props.background_color ||
+    nodeProps.background ||
+    props.background;
+  const backgroundValue = normalizeBackgroundValue(background);
   const isNumericWidth = width && !isNaN(Number(width));
   const widthStyle = isNumericWidth ? '100%' : typeof width === 'string' && width.includes('/') ? width : '100%';
   const maxWidth = isNumericWidth ? `${width}px` : undefined;
@@ -837,6 +892,7 @@ export const CraftSection = ({
           !noPadding && 'p-3',
           height ? 'overflow-hidden' : 'overflow-visible',
         )}
+        style={backgroundValue ? { background: backgroundValue } : undefined}
       >
         {children || <Placeholder name={name || 'Section'} />}
       </div>
@@ -1215,6 +1271,11 @@ export const Container = ({
   const id = useNodeId();
   const { enabled, actions } = usePageEditor();
   const { selected } = usePageNode();
+  const background =
+    props.layout_background ||
+    props.background_color ||
+    props.background;
+  const backgroundValue = normalizeBackgroundValue(background);
   const isNumericWidth = width && !isNaN(Number(width));
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [containerDropActive, setContainerDropActive] = React.useState(false);
@@ -1266,6 +1327,7 @@ export const Container = ({
       style={
         {
           ...props.style,
+          background: backgroundValue,
           height: height ? `${height}px` : 'auto',
           '--desktop-width': isNumericWidth ? `${width}px` : undefined,
         } as React.CSSProperties
@@ -2137,6 +2199,57 @@ export const CraftCustomHTML = (props: any) => {
 };
 CraftCustomHTML.craft = { displayName: 'Custom HTML', related: { settings: CustomHTMLSettings } };
 
+const AICustomSectionSettings = () => {
+  const { actions, props } = useSettings();
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <p className="text-sm font-medium">HTML Content</p>
+        <Textarea
+          value={props.html || ''}
+          onChange={(e) => actions.setProp((nodeProps: any) => (nodeProps.html = e.target.value))}
+          placeholder="<section><div>Your custom UI here...</div></section>"
+          rows={10}
+          className="font-mono text-xs"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="text-sm font-medium">Scoped CSS</p>
+        <Textarea
+          value={props.css || ''}
+          onChange={(e) => actions.setProp((nodeProps: any) => (nodeProps.css = e.target.value))}
+          placeholder='[data-ai-custom-section="section-id"] { animation: float 12s linear infinite; }'
+          rows={10}
+          className="font-mono text-xs"
+        />
+      </div>
+    </div>
+  );
+};
+
+export const CraftAICustomSection = (props: any) => {
+  const { enabled } = usePageEditor();
+  const id = useNodeId();
+  const { html, css } = props;
+  const scopeSelector = `[data-ai-custom-section="${id}"]`;
+
+  if (!html && !enabled) return null;
+
+  return (
+    <CraftSection name="AI Custom Section">
+      <div data-ai-custom-section={id} className="relative">
+        {css ? <style dangerouslySetInnerHTML={{ __html: css.replaceAll('__SECTION_SCOPE__', scopeSelector) }} /> : null}
+        {html ? (
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+        ) : (
+          <Placeholder name="AI Custom Section" description="AI-authored HTML and CSS block" />
+        )}
+      </div>
+    </CraftSection>
+  );
+};
+CraftAICustomSection.craft = { displayName: 'AI Custom Section', related: { settings: AICustomSectionSettings } };
+
 const SpacerSettings = () => {
   const { actions, props } = useSettings();
   return (
@@ -2276,6 +2389,7 @@ export const resolver: Record<string, React.ComponentType<any>> = {
   ImageBanner: CraftImageBanner,
   SocialLinks: CraftSocialLinks,
   CustomHTML: CraftCustomHTML,
+  AICustomSection: CraftAICustomSection,
   Spacer: CraftSpacer,
   Header: CraftHeader,
   Footer: CraftFooter,

--- a/lib/components/features/ai/manage/craft/resolver.tsx
+++ b/lib/components/features/ai/manage/craft/resolver.tsx
@@ -82,6 +82,86 @@ function normalizeBackgroundValue(background: unknown): string | undefined {
   return undefined;
 }
 
+function toCssSize(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${value}px`;
+  }
+
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (/^\d+(?:\.\d+)?$/.test(trimmed)) return `${trimmed}px`;
+
+  return trimmed;
+}
+
+function getDecorativeImageSource(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.trim() || undefined;
+  }
+
+  if (!value || typeof value !== 'object') return undefined;
+
+  const record = value as Record<string, unknown>;
+
+  return getDecorativeImageSource(
+    record.source ??
+    record.src ??
+    record.url ??
+    record.original ??
+    record.large2x ??
+    record.large ??
+    record.medium
+  );
+}
+
+function getDecorativeImagePositionClasses(position: unknown): string {
+  switch (position) {
+    case 'top-left':
+      return 'top-0 left-0';
+    case 'bottom-right':
+      return 'bottom-0 right-0';
+    case 'bottom-left':
+      return 'bottom-0 left-0';
+    case 'center-right':
+      return 'top-1/2 right-0 -translate-y-1/2';
+    case 'center-left':
+      return 'top-1/2 left-0 -translate-y-1/2';
+    case 'top-center':
+      return 'top-0 left-1/2 -translate-x-1/2';
+    case 'bottom-center':
+      return 'bottom-0 left-1/2 -translate-x-1/2';
+    case 'center':
+      return 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2';
+    case 'top-right':
+    default:
+      return 'top-0 right-0';
+  }
+}
+
+function normalizeDecorativeImage(value: unknown) {
+  if (!value || typeof value !== 'object') return undefined;
+
+  const record = value as Record<string, unknown>;
+  const src = getDecorativeImageSource(record);
+  if (!src) return undefined;
+
+  return {
+    src,
+    alt: typeof record.alt === 'string' ? record.alt : '',
+    positionClasses: getDecorativeImagePositionClasses(record.position),
+    className: typeof record.className === 'string' ? record.className : '',
+    width: toCssSize(record.width) ?? '160px',
+    height: toCssSize(record.height),
+    opacity: typeof record.opacity === 'number' ? record.opacity : undefined,
+    objectFit:
+      record.objectFit === 'cover' || record.objectFit === 'contain'
+        ? record.objectFit
+        : 'contain',
+  };
+}
+
 const useEvent = (props: any) => {
   const layoutState = useStoreManageLayout();
   return (layoutState.data as Event) || props.event;
@@ -1266,6 +1346,7 @@ export const Container = ({
   centerChildren,
   padding = '0',
   px = '1',
+  decorativeImage,
   ...props
 }: any) => {
   const id = useNodeId();
@@ -1276,6 +1357,7 @@ export const Container = ({
     props.background_color ||
     props.background;
   const backgroundValue = normalizeBackgroundValue(background);
+  const decorativeImageConfig = normalizeDecorativeImage(decorativeImage);
   const isNumericWidth = width && !isNaN(Number(width));
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [containerDropActive, setContainerDropActive] = React.useState(false);
@@ -1313,6 +1395,7 @@ export const Container = ({
       }}
       className={clsx(
         'flex flex-col gap-6 w-full transition-all relative flex-1',
+        decorativeImageConfig && 'isolate',
         centered && 'page mx-auto',
         centerChildren && 'items-center',
         padding === '8' ? 'py-8' : padding === '16' ? 'py-16' : padding === '32' ? 'py-32' : 'py-4',
@@ -1333,7 +1416,30 @@ export const Container = ({
         } as React.CSSProperties
       }
     >
-      {children}
+      {decorativeImageConfig ? (
+        <img
+          src={decorativeImageConfig.src}
+          alt={decorativeImageConfig.alt}
+          loading="lazy"
+          aria-hidden={decorativeImageConfig.alt ? undefined : true}
+          className={clsx(
+            'pointer-events-none select-none absolute z-0 max-w-none',
+            decorativeImageConfig.positionClasses,
+            decorativeImageConfig.objectFit === 'cover' ? 'object-cover' : 'object-contain',
+            decorativeImageConfig.className,
+          )}
+          style={{
+            width: decorativeImageConfig.width,
+            height: decorativeImageConfig.height,
+            opacity: decorativeImageConfig.opacity,
+          }}
+        />
+      ) : null}
+      {decorativeImageConfig ? (
+        <div className="contents [&>*]:relative [&>*]:z-[1]">
+          {children}
+        </div>
+      ) : children}
     </div>
   );
 };

--- a/lib/components/features/ai/manage/store.ts
+++ b/lib/components/features/ai/manage/store.ts
@@ -10,6 +10,12 @@ export type BuilderTabType = 'template' | 'sections' | 'theme';
 export type DesignModeType = 'builder' | 'ai';
 export type MobilePaneType = 'main' | 'chat' | 'config';
 export const defaultAvailableTabs: ActiveTabType[] = ['manage', 'design', 'preview'];
+export type PageCustomCode = {
+  css?: string;
+  head_html?: string;
+  body_html?: string;
+  scripts?: Array<{ src?: string; content?: string; strategy: string }>;
+};
 
 interface IStore {
   showSidebarLeft: boolean;
@@ -27,6 +33,10 @@ interface IStore {
   pageConfigId?: string;
   /** Last persisted PageConfig.theme — used for dirty-check and Reset in the theme editor */
   savedPageTheme?: Record<string, unknown>;
+  /** Last persisted PageConfig.custom_code — used for save round-tripping and preview reset. */
+  savedPageCustomCode?: PageCustomCode;
+  /** Current in-editor custom_code state, including AI-authored CSS. */
+  pageCustomCode?: PageCustomCode;
 }
 
 const defaultStore: IStore = {
@@ -77,5 +87,9 @@ export const storeManageLayout = {
   setFullScreen: (fullScreen: boolean) => aiManageLayoutStore.set(storeAtom, (prev) => ({ ...prev, fullScreen })),
   setPageConfigId: (pageConfigId: string | undefined) => aiManageLayoutStore.set(storeAtom, (prev) => ({ ...prev, pageConfigId })),
   setSavedPageTheme: (savedPageTheme: Record<string, unknown> | undefined) => aiManageLayoutStore.set(storeAtom, (prev) => ({ ...prev, savedPageTheme })),
+  setSavedPageCustomCode: (savedPageCustomCode: PageCustomCode | undefined) =>
+    aiManageLayoutStore.set(storeAtom, (prev) => ({ ...prev, savedPageCustomCode })),
+  setPageCustomCode: (pageCustomCode: PageCustomCode | undefined) =>
+    aiManageLayoutStore.set(storeAtom, (prev) => ({ ...prev, pageCustomCode })),
   reset: () => aiManageLayoutStore.set(storeAtom, { ...defaultStore }),
 };

--- a/lib/components/features/event/EventGuestSide.tsx
+++ b/lib/components/features/event/EventGuestSide.tsx
@@ -7,16 +7,14 @@ import {
   Event,
   GetEventDocument,
   GetEventQuery,
-  GetPageConfigDocument,
   GetPageConfigQuery,
-  PageConfigFragmentFragmentDoc,
   PageConfigOwnerType,
 } from '$lib/graphql/generated/backend/graphql';
 import { PageEditorProvider, usePageEditor } from '$lib/components/features/page-builder/context';
 import { PageRenderer } from '$lib/components/features/page-builder/renderer';
-import { useFragment } from '$lib/graphql/generated/backend/fragment-masking';
 import { useQuery } from '$lib/graphql/request';
 import { Badge, Button, Spacer } from '$lib/components/core';
+import { GetPageConfigWithCustomCodeDocument } from '$lib/graphql/custom/page-config';
 import { EDIT_KEY, generateUrl } from '$lib/utils/cnd';
 import { getEventCohosts, hosting, isAttending, isPromoter } from '$lib/utils/event';
 import { ThemeBuilderActionKind, useEventTheme } from '$lib/components/features/theme-builder/provider';
@@ -116,7 +114,7 @@ export function EventGuestSideContent({
     }
   }, [event]);
 
-  const { data: pageConfigData } = useQuery(GetPageConfigDocument, {
+  const { data: pageConfigData } = useQuery(GetPageConfigWithCustomCodeDocument, {
     variables: { ownerType: PageConfigOwnerType.Event, ownerId: event._id },
     initData: { getPageConfig: initPageConfig } as GetPageConfigQuery,
     // Skip client-side refetch when SSR already provided the page config (including null = confirmed no config).
@@ -124,7 +122,8 @@ export function EventGuestSideContent({
     skip: !event?._id || isEditable || initPageConfig !== undefined,
   });
   const pageConfig = pageConfigData?.getPageConfig;
-  const pageConfigFields = useFragment(PageConfigFragmentFragmentDoc, pageConfig);
+  const pageConfigFields = pageConfig as any;
+  const customPageCss = pageConfigFields?.custom_code?.css || undefined;
 
   React.useEffect(() => {
     if (pageConfigData === undefined) return;
@@ -353,5 +352,10 @@ export function EventGuestSideContent({
     );
   };
 
-  return renderContent();
+  return (
+    <div data-page-theme-root>
+      {customPageCss ? <style dangerouslySetInnerHTML={{ __html: customPageCss }} /> : null}
+      {renderContent()}
+    </div>
+  );
 }

--- a/lib/components/features/page-builder/hooks/ai-page-edit-bridge.ts
+++ b/lib/components/features/page-builder/hooks/ai-page-edit-bridge.ts
@@ -15,6 +15,8 @@ export interface AIPageEditTriggers {
   applySectionUpdate: (section: PageSection) => void;
   /** Apply a PageTheme returned by page_designer tool to the theme editor state. */
   applyTheme: (theme: Record<string, unknown>) => void;
+  /** Apply persisted custom page code returned by page_designer. */
+  applyCustomCode: (customCode: Record<string, unknown> | undefined) => void;
   /** Return current page as PageSection[] for persistence. */
   getSections: () => PageSection[];
   getStructureData: () => string | null;

--- a/lib/components/features/theme-builder/generator.tsx
+++ b/lib/components/features/theme-builder/generator.tsx
@@ -67,8 +67,14 @@ export function ThemeGenerator({
 
   const modeKey = mode === 'auto' ? 'dark' : mode;
   const isMinimalTheme = data.theme === 'minimal';
+  const isCustomTheme = data.theme === 'custom';
   const modeVars = data.variables?.[modeKey === 'dark' ? 'dark' : 'light'];
-  const backgroundColor = modeVars?.['--color-background'] || (isMinimalTheme ? (modeKey === 'light' ? 'var(--color-accent-50)' : 'var(--color-accent-950)') : undefined);
+  const backgroundColor = modeVars?.['--color-background'] ||
+    (isMinimalTheme
+      ? (modeKey === 'light' ? 'var(--color-accent-50)' : 'var(--color-accent-950)')
+      : isCustomTheme
+        ? (data.variables?.custom?.['--color-background'] as string | undefined)
+        : undefined);
   const selector = scopeSelector || '[data-theme-scope]';
 
   const scopedBackgroundStyle = scoped
@@ -77,7 +83,7 @@ export function ThemeGenerator({
         inset: 0,
         pointerEvents: 'none',
         zIndex: 0,
-        backgroundColor: isMinimalTheme ? backgroundColor : undefined,
+        backgroundColor: isMinimalTheme || isCustomTheme ? backgroundColor : undefined,
         ...style,
       } as React.CSSProperties)
     : style;
@@ -110,11 +116,12 @@ export function ThemeGenerator({
       )}
 
       {
-        !!(backgroundColor && isMinimalTheme) && (
+        !!(backgroundColor && (isMinimalTheme || isCustomTheme)) && (
           <style jsx global>
             {`
-              ${scoped ? `${selector} .background.minimal` : '.background.minimal'} {
+              ${scoped ? `${selector} .background.${data.theme}` : `.background.${data.theme}`} {
                 --minimal-color-bg: ${backgroundColor} !important;
+                background-color: ${backgroundColor} !important;
               }
             `}
           </style>

--- a/lib/components/features/theme-builder/store.ts
+++ b/lib/components/features/theme-builder/store.ts
@@ -2,7 +2,7 @@ import { ASSET_PREFIX } from '$lib/utils/constants';
 import { atom } from 'jotai';
 
 export type ThemeValues = {
-  theme?: 'default' | 'minimal' | 'shader' | 'pattern' | 'image' | 'passport';
+  theme?: 'default' | 'minimal' | 'shader' | 'pattern' | 'image' | 'passport' | 'custom';
   template?: {
     image?: string;
   };
@@ -205,11 +205,20 @@ const image: ThemePresetType = {
   },
 };
 
+const custom: ThemePresetType = {
+  image: `${ASSET_PREFIX}/assets/images/minimal.png`,
+  name: 'Custom',
+  ui: {
+    mode: 'all',
+  },
+};
+
 export const presets = {
   minimal,
   shader,
   pattern,
   image,
+  custom,
 };
 
 export const modes = [

--- a/lib/graphql/custom/page-config.ts
+++ b/lib/graphql/custom/page-config.ts
@@ -1,0 +1,208 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import gql from 'graphql-tag';
+
+import { PageConfigOwnerType } from '$lib/graphql/generated/backend/graphql';
+
+export type GetPageConfigWithCustomCodeQuery = {
+  __typename?: 'Query';
+  getPageConfig?: any | null;
+};
+
+export type GetPageConfigWithCustomCodeQueryVariables = {
+  id?: string | null;
+  ownerType?: PageConfigOwnerType | null;
+  ownerId?: string | null;
+};
+
+export const GetPageConfigWithCustomCodeDocument = gql`
+  query GetPageConfigWithCustomCode($id: MongoID, $ownerType: PageConfigOwnerType, $ownerId: MongoID) {
+    getPageConfig(_id: $id, owner_type: $ownerType, owner_id: $ownerId) {
+      _id
+      name
+      description
+      owner_id
+      owner_type
+      status
+      version
+      published_version
+      thumbnail_url
+      created_at
+      created_by
+      last_edited_by
+      locked_at
+      locked_by
+      template_id
+      template_version_installed
+      space_id
+      theme {
+        type
+        mode
+        colors {
+          accent
+        }
+        background {
+          type
+          value
+        }
+        fonts {
+          title {
+            family
+          }
+          body {
+            family
+          }
+        }
+        effects {
+          type
+          value
+        }
+        css_variables
+      }
+      custom_code {
+        css
+        head_html
+        body_html
+        scripts {
+          src
+          content
+          strategy
+        }
+      }
+      sections {
+        id
+        type
+        order
+        hidden
+        layout {
+          width
+          padding
+          columns
+          alignment
+          min_height
+          background {
+            type
+            value
+          }
+        }
+        props
+        data_binding {
+          mode
+          source {
+            type
+            field
+          }
+          overrides
+        }
+        craft_node_id
+        children {
+          id
+          type
+          order
+          hidden
+          layout {
+            width
+            padding
+            columns
+            alignment
+            min_height
+            background {
+              type
+              value
+            }
+          }
+          props
+          data_binding {
+            mode
+            source {
+              type
+              field
+            }
+            overrides
+          }
+          craft_node_id
+          children {
+            id
+            type
+            order
+            hidden
+            layout {
+              width
+              padding
+              columns
+              alignment
+              min_height
+              background {
+                type
+                value
+              }
+            }
+            props
+            data_binding {
+              mode
+              source {
+                type
+                field
+              }
+              overrides
+            }
+            craft_node_id
+            children {
+              id
+              type
+              order
+              hidden
+              layout {
+                width
+                padding
+                columns
+                alignment
+                min_height
+                background {
+                  type
+                  value
+                }
+              }
+              props
+              data_binding {
+                mode
+                source {
+                  type
+                  field
+                }
+                overrides
+              }
+              craft_node_id
+              children {
+                id
+                type
+                order
+                hidden
+                layout {
+                  width
+                  padding
+                  columns
+                  alignment
+                  min_height
+                  background {
+                    type
+                    value
+                  }
+                }
+                props
+                data_binding {
+                  mode
+                  source {
+                    type
+                    field
+                  }
+                  overrides
+                }
+                craft_node_id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+` as TypedDocumentNode<GetPageConfigWithCustomCodeQuery, GetPageConfigWithCustomCodeQueryVariables>;

--- a/lib/graphql/gql/backend/page-config.gql
+++ b/lib/graphql/gql/backend/page-config.gql
@@ -132,6 +132,16 @@ fragment PageConfigFragment on PageConfig {
     }
     css_variables
   }
+  custom_code {
+    css
+    head_html
+    body_html
+    scripts {
+      src
+      content
+      strategy
+    }
+  }
   sections {
     ...PageSectionFragment
   }

--- a/lib/utils/__tests__/page-sections-mapper.test.ts
+++ b/lib/utils/__tests__/page-sections-mapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { sectionsToNodes, type PageSection } from '$lib/utils/page-sections-mapper';
+import { nodesToSections, sectionToNodePatch, sectionsToNodes, type PageSection } from '$lib/utils/page-sections-mapper';
 
 describe('page-sections-mapper', () => {
   it('attaches flat top-level non-container sections to ROOT when root.children is empty', () => {
@@ -85,5 +85,127 @@ describe('page-sections-mapper', () => {
     expect(nodes.ROOT.type.resolvedName).toBe('Container');
     expect(nodes.ROOT.nodes).toEqual(['main-grid']);
     expect(nodes['main-grid'].parent).toBe('ROOT');
+  });
+
+  it('preserves extended layout fields when mapping sections to nodes and back', () => {
+    const section: PageSection = {
+      id: 'root',
+      type: 'layout_container',
+      order: 0,
+      hidden: false,
+      layout: { width: 'full', padding: 'none' },
+      props: { centered: false, width: '' },
+      children: [
+        {
+          id: 'main-grid',
+          type: 'columns',
+          order: 0,
+          hidden: false,
+          layout: { width: 'full', padding: 'none' },
+          props: { gap: '18', centered: true, width: '1080' },
+          children: [
+            {
+              id: 'main-col',
+              type: 'layout_col',
+              order: 0,
+              hidden: false,
+              layout: { width: '', padding: 'none' },
+              props: {},
+              children: [
+                {
+                  id: 'event-hero',
+                  type: 'event_hero',
+                  order: 0,
+                  hidden: false,
+                  layout: {
+                    width: 'full',
+                    padding: 'lg',
+                    alignment: 'center',
+                    min_height: '420px',
+                    background: { type: 'solid', value: 'green' },
+                  },
+                  props: { align: 'text-center' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const nodes = sectionsToNodes([section]);
+    const patch = sectionToNodePatch(section.children![0].children![0].children![0]);
+    const roundTrip = nodesToSections(JSON.stringify(nodes));
+
+    expect(nodes['event-hero'].props).toMatchObject({
+      align: 'text-center',
+      layout_width: 'full',
+      layout_padding: 'lg',
+      layout_alignment: 'center',
+      layout_min_height: '420px',
+      layout_background: { type: 'solid', value: 'green' },
+    });
+    expect(patch.props).toMatchObject({
+      layout_width: 'full',
+      layout_padding: 'lg',
+      layout_alignment: 'center',
+      layout_min_height: '420px',
+      layout_background: { type: 'solid', value: 'green' },
+    });
+    expect(roundTrip[0].children?.[0].children?.[0].children?.[0]).toMatchObject({
+      id: 'event-hero',
+      type: 'event_hero',
+      layout: {
+        width: 'full',
+        padding: 'lg',
+        alignment: 'center',
+        min_height: '420px',
+        background: { type: 'solid', value: 'green' },
+      },
+      props: { align: 'text-center' },
+    });
+  });
+
+  it('maps ai_custom_section to the custom renderer and preserves html/css props', () => {
+    const sections: PageSection[] = [
+      {
+        id: 'root',
+        type: 'layout_container',
+        order: 0,
+        hidden: false,
+        layout: { width: 'full', padding: 'none' },
+        props: { centered: false, width: '' },
+        children: [
+          {
+            id: 'ai-custom-1',
+            type: 'ai_custom_section',
+            order: 0,
+            hidden: false,
+            layout: { width: 'full', padding: 'md' },
+            props: {
+              html: '<div class="bubble-scene"></div>',
+              css: '[data-ai-custom-section="ai-custom-1"] .bubble-scene { min-height: 320px; }',
+            },
+          },
+        ],
+      },
+    ];
+
+    const nodes = sectionsToNodes(sections);
+    const roundTrip = nodesToSections(JSON.stringify(nodes));
+
+    expect(nodes['ai-custom-1'].type.resolvedName).toBe('AICustomSection');
+    expect(nodes['ai-custom-1'].props).toMatchObject({
+      html: '<div class="bubble-scene"></div>',
+      css: '[data-ai-custom-section="ai-custom-1"] .bubble-scene { min-height: 320px; }',
+    });
+    expect(roundTrip[0].children?.[0]).toMatchObject({
+      id: 'ai-custom-1',
+      type: 'ai_custom_section',
+      props: {
+        html: '<div class="bubble-scene"></div>',
+        css: '[data-ai-custom-section="ai-custom-1"] .bubble-scene { min-height: 320px; }',
+      },
+    });
   });
 });

--- a/lib/utils/page-sections-mapper.ts
+++ b/lib/utils/page-sections-mapper.ts
@@ -65,6 +65,7 @@ const TYPE_TO_RESOLVED: Record<string, string> = {
   video_embed: 'VideoEmbed',
   social_links: 'SocialLinks',
   custom_html: 'CustomHTML',
+  ai_custom_section: 'AICustomSection',
   spacer: 'Spacer',
   header: 'Header',
   footer: 'Footer',
@@ -80,6 +81,43 @@ const RESOLVED_TO_TYPE: Record<string, string> = Object.fromEntries(
 const CANVAS_TYPES = new Set([
   'layout_container', 'columns', 'layout_col', 'inline_grid', 'tabs', 'accordion',
 ]);
+
+const LAYOUT_PROP_KEYS = [
+  'layout_width',
+  'layout_padding',
+  'layout_columns',
+  'layout_alignment',
+  'layout_min_height',
+  'layout_background',
+] as const;
+
+type LayoutPropKey = (typeof LAYOUT_PROP_KEYS)[number];
+
+function layoutToNodeProps(section: PageSection['layout']): Record<LayoutPropKey, unknown> {
+  return {
+    layout_width: section.width,
+    layout_padding: section.padding,
+    layout_columns: section.columns,
+    layout_alignment: section.alignment,
+    layout_min_height: section.min_height,
+    layout_background: section.background,
+  };
+}
+
+function nodePropsToLayout(props: Record<string, unknown>): PageSection['layout'] {
+  return {
+    width: (props.layout_width as string) ?? 'contained',
+    padding: (props.layout_padding as string) ?? 'md',
+    columns: props.layout_columns as number | undefined,
+    alignment: props.layout_alignment as string | undefined,
+    min_height: props.layout_min_height as string | undefined,
+    background: props.layout_background as PageSection['layout']['background'],
+  };
+}
+
+export function resolveSectionTypeToResolvedName(type: string): string | undefined {
+  return TYPE_TO_RESOLVED[type];
+}
 
 // ─── sectionsToNodes ─────────────────────────────────────────────────────────
 
@@ -105,7 +143,7 @@ export function sectionsToNodes(sections: PageSection[]): Record<string, CraftNo
     nodes[nodeId] = {
       type: { resolvedName },
       isCanvas: CANVAS_TYPES.has(section.type),
-      props: { ...section.props, layout_width: section.layout.width, layout_padding: section.layout.padding },
+      props: { ...section.props, ...layoutToNodeProps(section.layout) },
       nodes: childIds,
       linkedNodes: {},
       parent: parentId,
@@ -179,11 +217,8 @@ export function nodesToSections(serialized: string): PageSection[] {
       type,
       order,
       hidden: node.hidden ?? false,
-      layout: {
-        width: (node.props?.layout_width as string) ?? 'contained',
-        padding: (node.props?.layout_padding as string) ?? 'md',
-      },
-      props: omit(node.props, ['layout_width', 'layout_padding']),
+      layout: nodePropsToLayout(node.props ?? {}),
+      props: omit(node.props, [...LAYOUT_PROP_KEYS]),
       craft_node_id: nodeId,
       children: children.length > 0 ? children : undefined,
     };
@@ -210,7 +245,15 @@ export function sectionToNodePatch(section: PageSection): {
   const nodeId = section.craft_node_id || section.id;
   const resolvedName = TYPE_TO_RESOLVED[section.type] ?? section.type;
 
-  return { nodeId, props: section.props, isNew: false, resolvedName };
+  return {
+    nodeId,
+    props: {
+      ...section.props,
+      ...layoutToNodeProps(section.layout),
+    },
+    isNew: false,
+    resolvedName,
+  };
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- load, preview, apply, and save AI-generated custom_code CSS in the page builder
- add ai_custom_section rendering with scoped HTML and CSS output
- support the new custom theme path without editing generated GraphQL artifacts

## Testing
- yarn test lib/utils/__tests__/page-sections-mapper.test.ts

## Notes
- depends on the lemonade-backend and lemonade-ai custom CSS PRs