### PR TITLE
fix: make page builder preview read-only

### DIFF
--- a/lib/components/features/ai/manage/ManageLayout.tsx
+++ b/lib/components/features/ai/manage/ManageLayout.tsx
@@ -194,7 +194,7 @@ function ManageLayout({
 
   return (
     <div className="h-dvh flex flex-col bg-overlay-primary dark" data-theme="dark">
-      <PageEditorProvider enabled={state.activeTab !== 'manage'}>
+      <PageEditorProvider enabled={state.activeTab === 'design'}>
         <Header showUI={false} />
         <EventThemeProvider
           key={`${state.layoutType}-${entity?._id || 'manage-theme-default'}`}

--- a/lib/components/features/ai/manage/ManageLayoutContent.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutContent.tsx
@@ -181,6 +181,12 @@ function ManageLayoutContent({
     }
   }, [ready, state.layoutType]);
 
+  React.useEffect(() => {
+    if (state.activeTab !== 'design' && selectedId !== null) {
+      actions.selectNode(null);
+    }
+  }, [actions, selectedId, state.activeTab]);
+
   const communityChatProps =
     state.layoutType === 'community' && community?._id
       ? ({
@@ -347,7 +353,7 @@ function ManageLayoutContent({
   return (
     <>
       <AnimatePresence>
-        {isSelected && state.activeTab !== 'manage' && (
+        {isSelected && state.activeTab === 'design' && (
           <motion.div
             initial={{ x: '-100%' }}
             animate={{ x: 0 }}


### PR DESCRIPTION
## Summary
- only enable the page editor context in design mode
- clear any selected node when leaving design mode
- hide the settings panel outside design so preview matches the guest-facing read-only render

## Testing
- source ~/.nvm/nvm.sh && nvm use default >/dev/null && yarn test __tests__/craft-resolver.test.tsx lib/utils/__tests__/page-sections-mapper.test.ts