### PR TITLE
feat: hide connectors nav item 

### DIFF
--- a/lib/components/layouts/sidebar.tsx
+++ b/lib/components/layouts/sidebar.tsx
@@ -112,21 +112,11 @@ const Sidebar = () => {
 
   const isActive = (item: { path: string }) =>
     pathname === item.path || (item.path.startsWith('/lemonheads') && pathname.includes(item.path));
-  const isConnectorsActive = pathname.includes('/s/manage/') && pathname.includes('/connectors');
   const isUpgradeActive = pathname.startsWith('/upgrade/');
 
   const handleUpgradeClick = () => {
     if (me || account) {
       if (mySpaces.length) router.push(`/upgrade/${mySpaces[0].slug || mySpaces[0]._id}`);
-      return;
-    }
-
-    signIn();
-  };
-
-  const handleConnectorsClick = () => {
-    if (me || account) {
-      if (mySpaces.length) router.push(`/s/manage/${mySpaces[0].slug || mySpaces[0]._id}/connectors`);
       return;
     }
 
@@ -246,16 +236,6 @@ const Sidebar = () => {
           </div>
 
           <div className="border-t p-3 pt-4 flex flex-col gap-3">
-            <SidebarFooterAction
-              toggle={toggle}
-              active={isConnectorsActive}
-              label="Connectors"
-              subtitle="Manage community integrations"
-              icon="icon-connector-line"
-              iconBadgeClassName="bg-primary"
-              onClick={handleConnectorsClick}
-            />
-
             <SidebarFooterAction
               toggle={toggle}
               active={isUpgradeActive}


### PR DESCRIPTION
## What
- Removed the `Connectors` item from the shared sidebar navigation
- Deleted the related sidebar-only connectors state and click handler cleanup

## Why
- The connectors shortcut should no longer appear in the main app navigation
- Removing the entry keeps the sidebar focused on currently supported top-level actions

## How
- Removed the `SidebarFooterAction` render for `Connectors` in `lib/components/layouts/sidebar.tsx`
- Deleted the now-unused `isConnectorsActive` and `handleConnectorsClick` logic

## Designs
- N/A

## Test Steps
- [ ] Open the app sidebar on desktop or mobile
- [ ] Confirm the `Connectors` nav item is no longer shown
- [ ] Confirm the `Upgrade to Pro` item still appears and works as before

## Other Notes
- [ ] Tests were not run for this small UI cleanup
