### PR TITLE
fix: event theme autosave and shuffle state

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -42,7 +42,7 @@ const aktura = localFont({
 const array = localFont({
   display: 'swap',
   src: '../public/assets/fonts/title/Array-Bold.otf',
-  variable: '--font-aktura',
+  variable: '--font-array',
 });
 
 const sarpanch = localFont({

--- a/lib/components/features/event/EventGuestSide.tsx
+++ b/lib/components/features/event/EventGuestSide.tsx
@@ -37,6 +37,7 @@ import { AttendeesSection } from './AttendeesSection';
 import { PendingCohostRequest } from './PendingCohostRequest';
 import { useMe } from '$lib/hooks/useMe';
 import { useTracker } from '$lib/hooks/useTracker';
+import { useMediaQuery } from '$lib/hooks/useMediaQuery';
 import { EventCollectibles } from '../event-collectibles';
 import { DEFAULT_LAYOUT_SECTIONS } from '$lib/utils/constants';
 
@@ -96,7 +97,7 @@ export function EventGuestSide({
 export function EventGuestSideContent({
   event,
   pageConfig: initPageConfig,
-  autoSave: _autoSave = true,
+  autoSave = true,
   isEditable = false,
   constrainToPageWidth = true,
 }: {
@@ -108,6 +109,7 @@ export function EventGuestSideContent({
 }) {
   const [state, themeDispatch] = useEventTheme();
   const [isClient, setIsClient] = React.useState(false);
+  const isDesktop = useMediaQuery('md');
 
   React.useEffect(() => {
     setIsClient(true);
@@ -129,6 +131,10 @@ export function EventGuestSideContent({
   const pageConfig = pageConfigData?.getPageConfig;
   const pageConfigFields = pageConfig as any;
   const customPageCss = pageConfigFields?.custom_code?.css || undefined;
+  const themeEditorPageConfigId = pageConfigFields?._id as string | undefined;
+  // Wait for the theme source to resolve before mounting the autosaving editor so it
+  // persists against PageConfig.theme instead of briefly writing the fallback event theme.
+  const isThemeEditorReady = !autoSave || initPageConfig !== undefined || pageConfigData !== undefined;
 
   React.useEffect(() => {
     if (pageConfigData === undefined) return;
@@ -169,6 +175,13 @@ export function EventGuestSideContent({
   const hosts = getEventCohosts(event);
 
   const router = useRouter();
+
+  const renderThemeBuilder = (viewport: 'desktop' | 'mobile') => {
+    if (!isClient || !isThemeEditorReady) return null;
+    if (viewport === 'desktop' && !isDesktop) return null;
+    if (viewport === 'mobile' && isDesktop) return null;
+    return <EventThemeBuilder eventId={event._id} pageConfigId={themeEditorPageConfigId} autoSave={autoSave} />;
+  };
 
   const renderSections = () => {
     return (event.layout_sections || DEFAULT_LAYOUT_SECTIONS).map((item) => {
@@ -221,7 +234,7 @@ export function EventGuestSideContent({
 
             {isHost && (
               <>
-                <EventThemeBuilder eventId={event._id} autoSave={false} />
+                {renderThemeBuilder('desktop')}
                 <div className="flex gap-2 items-center px-3.5 py-2 border border-card-border bg-accent-400/16 rounded-md">
                   <p className="text-accent-500">You have manage access for this event.</p>
                   <Button
@@ -276,7 +289,7 @@ export function EventGuestSideContent({
               <>
                 <Spacer className="h-4" />
                 <div className="flex flex-col gap-4">
-                  <EventThemeBuilder eventId={event._id} autoSave={false} />
+                  {renderThemeBuilder('mobile')}
                   <div className="flex gap-2 items-center px-3.5 py-2 border border-card-border bg-accent-400/16 rounded-md">
                     <p className="text-accent-500">You have manage access for this event.</p>
                     <Button

--- a/lib/components/features/event/EventGuestSide.tsx
+++ b/lib/components/features/event/EventGuestSide.tsx
@@ -108,6 +108,7 @@ export function EventGuestSideContent({
   constrainToPageWidth?: boolean;
 }) {
   const [state, themeDispatch] = useEventTheme();
+  const pageFontVariables = state.variables.font as React.CSSProperties | undefined;
   const [isClient, setIsClient] = React.useState(false);
   const isDesktop = useMediaQuery('md');
 
@@ -338,7 +339,7 @@ export function EventGuestSideContent({
           </div>
 
           <div className="space-y-2">
-            <h3 className="text-xl md:text-3xl font-bold">{event.title}</h3>
+            <h3 className="font-title text-xl md:text-3xl font-bold">{event.title}</h3>
 
             {!!hosts.length && (
               <p className="md:hidden text-secondary text-sm">
@@ -374,9 +375,10 @@ export function EventGuestSideContent({
     <div
       data-page-theme-root
       className={clsx(
-        'w-full',
+        'w-full font-body',
         constrainToPageWidth && 'page mx-auto',
       )}
+      style={pageFontVariables}
     >
       {customPageCss ? <style dangerouslySetInnerHTML={{ __html: customPageCss }} /> : null}
       {renderContent()}

--- a/lib/components/features/theme-builder/provider.tsx
+++ b/lib/components/features/theme-builder/provider.tsx
@@ -9,7 +9,7 @@ type ThemeContextValue = [ThemeValues, React.Dispatch<ThemeBuilderAction>];
 export const EventThemeContext = React.createContext<ThemeContextValue | null>(null);
 
 export function EventThemeProvider({ themeData, children }: React.PropsWithChildren & { themeData?: ThemeValues }) {
-  const [state, dispatch] = React.useReducer(reducers, themeData || defaultTheme);
+  const [state, dispatch] = React.useReducer(themeReducer, themeData || defaultTheme);
 
   React.useEffect(() => {
     if (themeData) {
@@ -32,7 +32,7 @@ export function useEventTheme(): [state: ThemeValues, dispatch: React.Dispatch<T
 export const ThemeContext = React.createContext<ThemeContextValue | null>(null);
 
 export function ThemeProvider({ themeData, children }: React.PropsWithChildren & { themeData?: ThemeValues }) {
-  const [state, dispatch] = React.useReducer(reducers, themeData || defaultTheme);
+  const [state, dispatch] = React.useReducer(themeReducer, themeData || defaultTheme);
   const value = React.useMemo(() => [state, dispatch] as ThemeContextValue, [state]);
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
@@ -64,7 +64,7 @@ export enum ThemeBuilderActionKind {
 
 export type ThemeBuilderAction = { type: ThemeBuilderActionKind; payload?: Partial<ThemeValues> };
 
-function reducers(state: ThemeValues, action: ThemeBuilderAction) {
+export function themeReducer(state: ThemeValues, action: ThemeBuilderAction) {
   switch (action.type) {
     case ThemeBuilderActionKind.select_template: {
       let payload = { ...action.payload };
@@ -115,25 +115,27 @@ function reducers(state: ThemeValues, action: ThemeBuilderAction) {
     case ThemeBuilderActionKind.random: {
       const [fontTitle, fontTitleVariable] = getRandomFont('title');
       const [fontBody, fontBodyVariable] = getRandomFont('body');
+      const activeTheme = !state.theme || state.theme === 'default' ? 'minimal' : state.theme;
 
       let payload: ThemeValues = {
         ...state,
+        theme: activeTheme,
         font_title: fontTitle,
         font_body: fontBody,
         variables: { ...state.variables, font: { '--font-title': fontTitleVariable, '--font-body': fontBodyVariable } },
       };
 
-      if (payload.theme === 'minimal') {
+      if (activeTheme === 'minimal') {
         payload = { ...payload, config: { ...payload.config, color: getRandomColor(), name: '' } };
       }
 
-      if (payload.theme === 'shader') {
+      if (activeTheme === 'shader') {
         const index = Math.floor(Math.random() * shaders.length);
         const shader = shaders[index];
         payload = { ...payload, config: { ...payload.config, name: shader.name, color: shader.accent } };
       }
 
-      if (payload.theme === 'pattern') {
+      if (activeTheme === 'pattern') {
         const index = Math.floor(Math.random() * patterns.length);
         const pattern = patterns[index];
         payload = { ...payload, config: { ...payload.config, name: pattern } };


### PR DESCRIPTION
## What
- Fixed guest-facing event theme edits to save against the resolved `PageConfig` theme source.
- Prevented duplicate theme autosave mutations from firing on guest event pages.
- Restored shuffle behavior for legacy `default` themes by normalizing them to the active `minimal` theme state before randomizing.

## Why
- Theme changes on the guest-facing event page could save inconsistently because the editor was not always targeting the persisted page-config theme.
- Desktop and mobile theme builders could both mount and trigger duplicate GraphQL saves for the same change.
- Shuffle could appear broken on minimal/default themes because the runtime state did not match the UI’s effective theme label.

## How
- Updated `EventGuestSide` to wait for page-config resolution and pass the resolved `pageConfigId` into the guest-page theme builder.
- Scoped the guest-page autosaving theme builder to the active breakpoint so only one live autosave source is mounted at a time.
- Exported the shared theme reducer and normalized `default` to `minimal` inside the random-theme path before applying random color and font changes.

## Designs
- N/A

## Test Steps
- [ ] Open a guest-facing event page as a host.
- [ ] Change the event theme and confirm the preview updates immediately.
- [ ] Check the network tab and confirm only one theme save mutation fires per change.
- [ ] Refresh the guest-facing event page and confirm the updated theme persists.
- [ ] Start from the default/minimal theme and click shuffle.
- [ ] Confirm the shuffled theme updates instead of appearing stuck.

## Other Notes
- No design artifacts are attached for this change.
- No automated tests were added in this branch.
