### PR TITLE
feat: add cancel support for in-flight AI chat

### DIFF
--- a/app/api/ai/graphql/route.ts
+++ b/app/api/ai/graphql/route.ts
@@ -1,6 +1,15 @@
 import * as Sentry from '@sentry/nextjs';
 import { NextRequest } from 'next/server';
 
+function isAbortError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const name = 'name' in error ? String(error.name) : '';
+  const message = 'message' in error ? String(error.message) : '';
+
+  return name === 'AbortError' || message === 'AbortError' || message === 'cancelled' || /abort/i.test(message);
+}
+
 function getUpstreamAiUrl() {
   const aiUrl = process.env.AI_API_HTTP || process.env.NEXT_PUBLIC_AI_API_HTTP;
 
@@ -36,6 +45,7 @@ export async function POST(request: NextRequest) {
       headers,
       body,
       cache: 'no-store',
+      signal: request.signal,
     });
 
     const responseHeaders = new Headers();
@@ -54,6 +64,10 @@ export async function POST(request: NextRequest) {
       headers: responseHeaders,
     });
   } catch (error) {
+    if (request.signal.aborted || isAbortError(error)) {
+      return new Response(null, { status: 499 });
+    }
+
     Sentry.captureException(error);
     return Response.json({ error: 'AI proxy request failed.' }, { status: 502 });
   }

--- a/lib/components/features/ai/InputChat.tsx
+++ b/lib/components/features/ai/InputChat.tsx
@@ -9,8 +9,14 @@ import Image from 'next/image';
 
 import { Button, Card, drawer, Menu, MenuItem, toast } from '$lib/components/core';
 
-import { useClient, useMutation, useQuery } from '$lib/graphql/request';
-import { AiConfigFieldsFragment, Config, GetListAiConfigDocument, RunAiChatDocument } from '$lib/graphql/generated/ai/graphql';
+import { isAbortError, useClient, useMutation, useQuery } from '$lib/graphql/request';
+import {
+  AiConfigFieldsFragment,
+  Config,
+  GetListAiConfigDocument,
+  RunAiChatDocument,
+  RunAiChatMutation,
+} from '$lib/graphql/generated/ai/graphql';
 import { aiChatClient } from '$lib/graphql/request/instances';
 import { AI_CONFIG } from '$lib/utils/constants';
 import {
@@ -23,7 +29,7 @@ import {
 } from '$lib/graphql/generated/backend/graphql';
 import { useUpdateEvent } from '$lib/components/features/event-manage/store';
 import { EditEventDrawer } from '../event-manage/drawers/EditEventDrawer';
-import { AIChatActionKind, Message, useAIChat } from './provider';
+import { AIChatActionKind, Message, useAIChat, useAIChatRequest } from './provider';
 import { communityAvatar } from '$lib/utils/community';
 import { useMe } from '$lib/hooks/useMe';
 import { getAIPageEditTriggers } from '$lib/components/features/page-builder/hooks/ai-page-edit-bridge';
@@ -31,6 +37,14 @@ import { getAIPageEditTriggers } from '$lib/components/features/page-builder/hoo
 const PLACEHOLDER_PHRASES = ['create an event', 'create a community', 'launch a coin'];
 const TYPING_MS = 80;
 const PAUSE_AFTER_PHRASE_MS = 1500;
+
+function getErrorMessage(error: unknown) {
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error.message;
+  }
+
+  return 'Something went wrong';
+}
 
 type InputChatProps = {
   variant?: 'default' | 'home';
@@ -53,8 +67,11 @@ export function InputChat({
 }: InputChatProps) {
   const router = useRouter();
   const [state, dispatch] = useAIChat();
+  const { activeRequestRef, running, setRunning } = useAIChatRequest();
   const [input, setInput] = React.useState('');
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const previousSessionRef = React.useRef(state.session);
+  const requestIdRef = React.useRef(0);
   const { client } = useClient();
   const updateEvent = useUpdateEvent();
 
@@ -100,6 +117,16 @@ export function InputChat({
     if (!isIdle) setAnim({ phraseIndex: 0, charCount: 0 });
   }, [isIdle]);
 
+  React.useEffect(() => {
+    if (previousSessionRef.current === state.session) return;
+
+    previousSessionRef.current = state.session;
+    activeRequestRef.current?.controller.abort();
+    activeRequestRef.current = null;
+    setRunning(false);
+    dispatch({ type: AIChatActionKind.set_thinking, payload: { thinking: false } });
+  }, [activeRequestRef, dispatch, setRunning, state.session]);
+
   const applyPageDesign = async (payload: unknown, message: string) => {
     const triggers = getAIPageEditTriggers();
     if (!triggers) {
@@ -139,127 +166,118 @@ export function InputChat({
     toast.success(message);
   };
 
-  const [run, { loading }] = useMutation(
-    RunAiChatDocument,
-    {
-      onComplete: (_, income) => {
-        dispatch({ type: AIChatActionKind.set_thinking, payload: { thinking: false } });
+  const [run] = useMutation(RunAiChatDocument, undefined, aiChatClient);
 
-        let runResult = income.run;
-        if (typeof runResult.metadata === 'string') {
-          try {
-            runResult = { ...runResult, metadata: JSON.parse(runResult.metadata) };
-          } catch (e) {
-            console.error('Failed to parse metadata', e);
+  const handleRunResult = async (income: RunAiChatMutation) => {
+    let runResult = income.run;
+    if (typeof runResult.metadata === 'string') {
+      try {
+        runResult = { ...runResult, metadata: JSON.parse(runResult.metadata) };
+      } catch (e) {
+        console.error('Failed to parse metadata', e);
+      }
+    }
+
+    dispatch({ type: AIChatActionKind.add_message, payload: { messages: [{ ...runResult, role: 'assistant' }] } });
+
+    const tool = runResult.metadata?.tool;
+    await match(tool?.name)
+      .with('create_event', async () => {
+        dispatch({
+          type: AIChatActionKind.add_message,
+          payload: { messages: [{ message: 'Redicting...', role: 'assistant' }] },
+        });
+
+        const res = await aiChatClient.query({
+          query: GetListAiConfigDocument,
+          variables: { filter: { events_eq: tool.data._id } },
+        });
+
+        delay(() => router.push(`/agent/e/manage/${tool?.data?.shortid}`), 2000);
+        delay(() => {
+          dispatch({ type: AIChatActionKind.reset });
+          if (res.data?.configs?.items?.length) {
+            const config = res.data.configs.items[0] as AiConfigFieldsFragment;
+            dispatch({
+              type: AIChatActionKind.set_config,
+              payload: { config: config._id, configs: res.data.configs.items as Config[] },
+            });
           }
+        }, 2500);
+      })
+      .with('update_event', async () => {
+        const data = tool.data;
+        const res = await client.query({
+          query: GetEventDocument,
+          variables: { id: data._id },
+          fetchPolicy: 'network-only',
+        });
+        if (res.data?.getEvent) {
+          client.writeFragment({ id: `Event:${data._id}`, data: res.data.getEvent });
+          updateEvent(res.data.getEvent as Partial<Event>);
         }
+      })
+      .with('publish_event', async () => {
+        const data = tool.data;
+        const res = await client.query({
+          query: GetEventDocument,
+          variables: { id: data._id },
+          fetchPolicy: 'network-only',
+        });
+        if (res.data?.getEvent) {
+          client.writeFragment({ id: `Event:${data._id}`, data: res.data.getEvent });
+          updateEvent(res.data.getEvent as Partial<Event>);
+        }
+      })
+      .with('create_space', async () => {
+        dispatch({
+          type: AIChatActionKind.add_message,
+          payload: { messages: [{ message: 'Redicting...', role: 'assistant' }] },
+        });
 
-        dispatch({ type: AIChatActionKind.add_message, payload: { messages: [{ ...runResult, role: 'assistant' }] } });
+        const res = await aiChatClient.query({
+          query: GetListAiConfigDocument,
+          variables: { filter: { spaces_eq: tool.data._id } },
+        });
 
-        const tool = runResult.metadata?.tool;
-        match(tool?.name)
-          .with('create_event', async () => {
+        delay(() => router.push(`/agent/s/manage/${tool?.data?._id}`), 2000);
+        delay(() => {
+          dispatch({ type: AIChatActionKind.reset });
+          if (res.data?.configs?.items?.length) {
+            const config = res.data.configs.items[0] as AiConfigFieldsFragment;
             dispatch({
-              type: AIChatActionKind.add_message,
-              payload: { messages: [{ message: 'Redicting...', role: 'assistant' }] },
+              type: AIChatActionKind.set_config,
+              payload: { config: config._id, configs: res.data.configs.items as Config[] },
             });
-
-            const res = await aiChatClient.query({
-              query: GetListAiConfigDocument,
-              variables: { filter: { events_eq: tool.data._id } },
-            });
-
-            delay(() => router.push(`/agent/e/manage/${tool?.data?.shortid}`), 2000);
-            delay(() => {
-              dispatch({ type: AIChatActionKind.reset });
-              if (res.data?.configs?.items?.length) {
-                const config = res.data.configs.items[0] as AiConfigFieldsFragment;
-                dispatch({
-                  type: AIChatActionKind.set_config,
-                  payload: { config: config._id, configs: res.data.configs.items as Config[] },
-                });
-              }
-            }, 2500);
-          })
-          .with('update_event', async () => {
-            const data = tool.data;
-            const res = await client.query({
-              query: GetEventDocument,
-              variables: { id: data._id },
-              fetchPolicy: 'network-only',
-            });
-            if (res.data?.getEvent) {
-              client.writeFragment({ id: `Event:${data._id}`, data: res.data.getEvent });
-              updateEvent(res.data.getEvent as Partial<Event>);
-            }
-          })
-          .with('publish_event', async () => {
-            const data = tool.data;
-            const res = await client.query({
-              query: GetEventDocument,
-              variables: { id: data._id },
-              fetchPolicy: 'network-only',
-            });
-            if (res.data?.getEvent) {
-              client.writeFragment({ id: `Event:${data._id}`, data: res.data.getEvent });
-              updateEvent(res.data.getEvent as Partial<Event>);
-            }
-          })
-          .with('create_space', async () => {
-            dispatch({
-              type: AIChatActionKind.add_message,
-              payload: { messages: [{ message: 'Redicting...', role: 'assistant' }] },
-            });
-
-            const res = await aiChatClient.query({
-              query: GetListAiConfigDocument,
-              variables: { filter: { spaces_eq: tool.data._id } },
-            });
-
-            delay(() => router.push(`/agent/s/manage/${tool?.data?._id}`), 2000);
-            delay(() => {
-              dispatch({ type: AIChatActionKind.reset });
-              if (res.data?.configs?.items?.length) {
-                const config = res.data.configs.items[0] as AiConfigFieldsFragment;
-                dispatch({
-                  type: AIChatActionKind.set_config,
-                  payload: { config: config._id, configs: res.data.configs.items as Config[] },
-                });
-              }
-            }, 2500);
-          })
-          .with('update_space', async () => {
-            const data = tool.data;
-            const res = await client.query({
-              query: GetSpaceDocument,
-              variables: { id: data._id },
-              fetchPolicy: 'network-only',
-            });
-            if (res.data?.getSpace) client.writeFragment({ id: `Space:${data._id}`, data: res.data.getSpace });
-          })
-          .with('create_page_config', async () => {
-            await applyPageDesign(tool.data, 'Design applied!');
-          })
-          .with('page_designer', async () => {
-            await applyPageDesign(tool.data, 'Design applied!');
-          })
-          .with('generate_page_from_description', async () => {
-            await applyPageDesign(tool.data, 'Design applied!');
-          })
-          .with('update_page_config_section', async () => {
-            await applyPageDesign(tool.data, 'Design updated!');
-          })
-          .with('section_designer', async () => {
-            await applySectionUpdate(tool.data, 'Section updated!');
-          });
-      },
-      onError: (error) => {
-        toast.error(error.message);
-        dispatch({ type: AIChatActionKind.set_thinking, payload: { thinking: false } });
-      },
-    },
-    aiChatClient,
-  );
+          }
+        }, 2500);
+      })
+      .with('update_space', async () => {
+        const data = tool.data;
+        const res = await client.query({
+          query: GetSpaceDocument,
+          variables: { id: data._id },
+          fetchPolicy: 'network-only',
+        });
+        if (res.data?.getSpace) client.writeFragment({ id: `Space:${data._id}`, data: res.data.getSpace });
+      })
+      .with('create_page_config', async () => {
+        await applyPageDesign(tool.data, 'Design applied!');
+      })
+      .with('page_designer', async () => {
+        await applyPageDesign(tool.data, 'Design applied!');
+      })
+      .with('generate_page_from_description', async () => {
+        await applyPageDesign(tool.data, 'Design applied!');
+      })
+      .with('update_page_config_section', async () => {
+        await applyPageDesign(tool.data, 'Design updated!');
+      })
+      .with('section_designer', async () => {
+        await applySectionUpdate(tool.data, 'Section updated!');
+      })
+      .otherwise(async () => undefined);
+  };
 
   React.useEffect(() => {
     if (textareaRef.current) {
@@ -273,9 +291,15 @@ export function InputChat({
 
   const handleSubmit = async () => {
     const text = input.trim();
-    if (!text) {
+    if (!text || running) {
       return;
     }
+
+    const controller = new AbortController();
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    activeRequestRef.current = { id: requestId, controller };
+
     const pageEditTriggers = getAIPageEditTriggers();
     const runData = {
       ...((state.data as Record<string, unknown> | undefined) || {}),
@@ -286,9 +310,10 @@ export function InputChat({
 
     dispatch({ type: AIChatActionKind.add_message, payload: { messages: [{ message: text, role: 'user' }] } });
     dispatch({ type: AIChatActionKind.set_thinking, payload: { thinking: true } });
+    setRunning(true);
     setInput('');
 
-    run({
+    const { data, error } = await run({
       variables: {
         message: text,
         config: configOverride || state.config || AI_CONFIG,
@@ -296,7 +321,38 @@ export function InputChat({
         data: runData,
         standId: state.standId || fixedSpaceId,
       },
+      signal: controller.signal,
     });
+
+    if (activeRequestRef.current?.id !== requestId) {
+      return;
+    }
+
+    activeRequestRef.current = null;
+    setRunning(false);
+    dispatch({ type: AIChatActionKind.set_thinking, payload: { thinking: false } });
+
+    if (error) {
+      if (!isAbortError(error)) {
+        toast.error(getErrorMessage(error));
+      }
+      return;
+    }
+
+    if (!data) {
+      return;
+    }
+
+    await handleRunResult(data);
+  };
+
+  const handleCancel = () => {
+    if (!activeRequestRef.current) return;
+
+    activeRequestRef.current.controller.abort();
+    activeRequestRef.current = null;
+    setRunning(false);
+    dispatch({ type: AIChatActionKind.set_thinking, payload: { thinking: false } });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -330,7 +386,7 @@ export function InputChat({
             </div>
           )}
           <textarea
-            disabled={loading}
+            disabled={running}
             ref={textareaRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -398,13 +454,30 @@ export function InputChat({
                 }
               />
             )}
-            <Button
-              icon="icon-arrow-foward-sharp -rotate-90"
-              size="sm"
-              onClick={handleSubmit}
-              loading={loading}
-              disabled={!input.trim()}
-            />
+            {running ? (
+              <Button
+                size="sm"
+                variant="tertiary-alt"
+                className="group p-[8px]"
+                onClick={handleCancel}
+                aria-label="Cancel AI response"
+              >
+                <span
+                  aria-hidden="true"
+                  className="relative block size-4 rounded-full bg-primary shadow-[inset_0_0_0_1px_rgba(0,0,0,0.08)] transition-colors group-hover:bg-overlay-primary group-hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12)]"
+                >
+                  <span className="absolute left-1/2 top-1/2 size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-[2px] bg-overlay-primary transition-colors group-hover:bg-primary" />
+                </span>
+              </Button>
+            ) : (
+              <Button
+                icon="icon-arrow-foward-sharp -rotate-90"
+                size="sm"
+                onClick={handleSubmit}
+                disabled={!input.trim()}
+                aria-label="Send message"
+              />
+            )}
           </div>
         </div>
       </Card.Content>

--- a/lib/components/features/ai/provider.tsx
+++ b/lib/components/features/ai/provider.tsx
@@ -17,6 +17,11 @@ export type Message = Partial<RunResult> & {
   role: 'user' | 'assistant';
 };
 
+export type ActiveAIRequest = {
+  id: number;
+  controller: AbortController;
+} | null;
+
 type State = {
   toggleChat: boolean;
   session: string;
@@ -64,6 +69,11 @@ export enum AIChatActionKind {
 export type AIChatAction = { type: AIChatActionKind; payload?: Partial<State> };
 
 export const AIChatContext = React.createContext<[State, React.Dispatch<AIChatAction>] | null>(null);
+const AIChatRequestContext = React.createContext<{
+  activeRequestRef: React.MutableRefObject<ActiveAIRequest>;
+  running: boolean;
+  setRunning: React.Dispatch<React.SetStateAction<boolean>>;
+} | null>(null);
 
 export function AIChatProvider({ children, initialConfigs }: { children: React.ReactNode; initialConfigs?: Config[] }) {
   const initialMessages: Message[] = [];
@@ -84,15 +94,44 @@ export function AIChatProvider({ children, initialConfigs }: { children: React.R
     config: initialConfigs?.length ? initialConfigs[0]._id : AI_CONFIG,
     messages: initialMessages,
   });
+  const [running, setRunning] = React.useState(false);
+  const activeRequestRef = React.useRef<ActiveAIRequest>(null);
 
   const value = React.useMemo(() => [state, dispatch] as [State, React.Dispatch<AIChatAction>], [state]);
+  const requestValue = React.useMemo(
+    () => ({
+      activeRequestRef,
+      running,
+      setRunning,
+    }),
+    [running],
+  );
 
-  return <AIChatContext.Provider value={value}>{children}</AIChatContext.Provider>;
+  React.useEffect(
+    () => () => {
+      activeRequestRef.current?.controller.abort();
+      activeRequestRef.current = null;
+    },
+    [],
+  );
+
+  return (
+    <AIChatContext.Provider value={value}>
+      <AIChatRequestContext.Provider value={requestValue}>{children}</AIChatRequestContext.Provider>
+    </AIChatContext.Provider>
+  );
 }
 
 export function useAIChat(): [state: State, dispatch: React.Dispatch<AIChatAction>] {
   const context = React.useContext(AIChatContext);
   if (!context) throw new Error('useAIChat must be used within a AIChatProvider');
+
+  return context;
+}
+
+export function useAIChatRequest() {
+  const context = React.useContext(AIChatRequestContext);
+  if (!context) throw new Error('useAIChatRequest must be used within a AIChatProvider');
 
   return context;
 }

--- a/lib/graphql/request/client.ts
+++ b/lib/graphql/request/client.ts
@@ -31,6 +31,7 @@ interface QueryRequest<T, V extends object> {
   initData?: T | null;
   fetchPolicy?: FetchPolicy;
   headers?: HeadersInit;
+  signal?: AbortSignal;
   resolve: (result: { data: T | null; error: unknown }) => void;
   reject: (error: unknown) => void;
 }
@@ -38,6 +39,15 @@ interface QueryRequest<T, V extends object> {
 interface RequestConfig {
   cache?: 'no-store' | 'no-cache';
   credentials?: 'omit' | 'include' | 'same-origin';
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const name = 'name' in error ? String(error.name) : '';
+  const message = 'message' in error ? String(error.message) : '';
+
+  return name === 'AbortError' || message === 'AbortError' || message === 'cancelled' || /abort/i.test(message);
 }
 
 export class GraphqlClient {
@@ -65,12 +75,14 @@ export class GraphqlClient {
     fetchPolicy = 'cache-first',
     headers,
     initData,
+    signal,
   }: {
     query: TypedDocumentNode<T, V>;
     headers?: HeadersInit;
     variables?: V;
     fetchPolicy?: FetchPolicy;
     initData?: T;
+    signal?: AbortSignal;
   }): Promise<{ data: T | null; error: unknown }> {
     return new Promise((resolve, reject) => {
       this.queue.push({
@@ -80,6 +92,7 @@ export class GraphqlClient {
         headers: this.getHeaders(headers),
         initData,
         fetchPolicy,
+        signal,
         resolve,
         reject,
       });
@@ -91,10 +104,12 @@ export class GraphqlClient {
     query,
     variables,
     headers,
+    signal,
   }: {
     query: TypedDocumentNode<T, V>;
     variables?: V;
     headers?: HeadersInit;
+    signal?: AbortSignal;
   }): Promise<{ data: T | null; error: unknown }> {
     return new Promise((resolve, reject) => {
       this.queue.push({
@@ -102,6 +117,7 @@ export class GraphqlClient {
         query,
         variables,
         headers: this.getHeaders(headers),
+        signal,
         resolve,
         reject,
       });
@@ -151,21 +167,36 @@ export class GraphqlClient {
 
     let result = initData;
     if (!result) {
-      result = await this.client.request(request.query, request.variables, headers as HeadersInit);
+      result = await this.client.request({
+        document: request.query,
+        variables: request.variables,
+        requestHeaders: headers as HeadersInit,
+        signal: request.signal,
+      });
     }
     this.cache?.normalizeAndStore(request.query, request.variables, result);
     request.resolve({ data: result, error: null });
   }
 
   private async executeNetworkRequest(request: QueryRequest<any, any>) {
-    const { query, variables, headers } = request;
-    const result = await this.client.request(query, variables, headers as HeadersInit);
+    const { query, variables, headers, signal } = request;
+    const result = await this.client.request({
+      document: query,
+      variables,
+      requestHeaders: headers as HeadersInit,
+      signal,
+    });
 
     this.cache?.normalizeAndStore(query, variables, result);
     request.resolve({ data: result, error: null });
   }
 
   private handleRequestError(request: QueryRequest<any, any>, error: unknown) {
+    if (request.signal?.aborted || isAbortError(error)) {
+      request.resolve({ data: null, error });
+      return;
+    }
+
     // P0-4: Report GraphQL errors to Sentry with operation context
     const operationName = (request.query.definitions?.[0] as any)?.name?.value || 'unknown';
     const operationType = (request.query.definitions?.[0] as any)?.operation || 'query';

--- a/lib/graphql/request/hooks.tsx
+++ b/lib/graphql/request/hooks.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { MutationOptions, QueryOptions } from './type';
-import { GraphqlClient } from './client';
+import { GraphqlClient, isAbortError } from './client';
 import { defaultClient } from './instances';
 
 function isEqual(a: any, b: any): boolean {
@@ -163,18 +163,20 @@ export function useMutation<T, V extends object>(
       query,
       variables: merged.variables,
       fetchPolicy: 'network-only',
+      signal: merged.signal,
     });
+    const aborted = isAbortError(error);
 
     setData((prev) => {
       if (isEqual(prev, result)) return prev;
       return result as T;
     });
 
-    setError(error);
+    setError(aborted ? null : error);
     setLoading(false);
-    if (error) {
+    if (error && !aborted) {
       merged.onError?.(error as any);
-    } else {
+    } else if (!error) {
       merged.onComplete?.(client, result as T);
     }
     return { data: result as T, error, loading: false, client };
@@ -182,5 +184,4 @@ export function useMutation<T, V extends object>(
 
   return [mutate, { data, error, client, loading }, client];
 }
-
 

--- a/lib/graphql/request/type.ts
+++ b/lib/graphql/request/type.ts
@@ -9,6 +9,7 @@ export type QueryOptions<T, V> = {
 
 export type MutationOptions<T, V> = {
   variables?: V;
+  signal?: AbortSignal;
   onError?: (error: Error) => void;
   onComplete?: (client: GraphqlClient, response: T) => void;
 };


### PR DESCRIPTION
## What
- Added cancel support for in-flight AI chat requests in the shared `AIChat` / `InputChat` flow.
- Replaced the send button with a stop control while a chat request is running.
- Moved active AI request state into the chat provider so cancel state survives the welcome-to-messages layout swap.
- Forwarded `AbortSignal` through the shared GraphQL client and the AI proxy route.
- Suppressed abort/cancel errors so stopping a request does not show an error toast or report noise to Sentry.

## Why
- Users need a way to stop long-running AI responses after submitting a prompt.
- The previous client-side approach could not preserve cancel state once the chat UI remounted.
- Abort handling should be treated as expected user behavior, not as an operational failure.

## How
- Extended `MutationOptions` and the shared GraphQL request path to accept and forward `signal`.
- Updated the GraphQL client to detect abort errors, resolve cleanly, and skip Sentry reporting for cancellations.
- Updated the AI proxy route to pass `request.signal` upstream and return early for aborted requests.
- Refactored `InputChat` to manage a single active request via provider-backed state, guard against stale responses, and clear `thinking` on cancel or session reset.
- Swapped the loading/send button for a custom circle-stop glyph with hover-safe contrast treatment.

## Designs
- N/A

## Test Steps
- [ ] Open any surface that uses `AIChat` / `InputChat`.
- [ ] Submit a prompt and confirm the send button changes into the stop control while the assistant is thinking.
- [ ] Click the stop control before the response completes.
- [ ] Confirm the submitted user message stays in the transcript.
- [ ] Confirm the assistant reply is not appended after cancel.
- [ ] Confirm the composer returns to the idle send state without showing an error toast.
- [ ] Reset or switch the AI session during an in-flight request and confirm no stale reply appears afterward.

## Other Notes
- Regression tests that were drafted for this change were removed from the branch per request.
- Verification in this branch is limited to implementation review and diff checks; no automated test run is included in this PR.
