### PR TITLE
feat: add Kintsugi Ranch homepage smoke test

### DIFF
--- a/e2e/kintsugi-ranch.spec.ts
+++ b/e2e/kintsugi-ranch.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Kintsugi Ranch smoke test', () => {
+  test('homepage shows Kintsugi Ranch text', async ({ page }) => {
+    await page.goto('https://kintsugiranch.com/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByRole('heading', { name: 'Kintsugi Ranch' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What
- Added a Playwright smoke test for `https://kintsugiranch.com/`
- Asserted the homepage shows the visible `Kintsugi Ranch` heading

## Why
- Adds a simple external-site availability check for the Kintsugi Ranch homepage
- Helps catch regressions where the landing page loads but expected branded content is missing

## How
- Added a focused E2E spec under `e2e/`
- Used `page.goto()` against the full external URL instead of relying on the local base URL
- Matched the visible heading via `getByRole('heading', { name: 'Kintsugi Ranch' })` to avoid false matches on the page title

## Designs
- N/A

## Test Steps
- [ ] Run `yarn playwright test e2e/kintsugi-ranch.spec.ts --project=chromium --reporter=line`
- [ ] Confirm the browser opens `https://kintsugiranch.com/`
- [ ] Confirm the test passes when the `Kintsugi Ranch` heading is visible

## Other Notes
- Verified locally with the Chromium Playwright project
- Cross-browser validation was not completed in the sandboxed environment
