### PR TITLE
fix: community padding

### DIFF
--- a/lib/components/features/ai/manage/ManageLayoutContent.tsx
+++ b/lib/components/features/ai/manage/ManageLayoutContent.tsx
@@ -372,7 +372,7 @@ function ManageLayoutContent({
         )}
       </AnimatePresence>
 
-      <div className="hidden md:flex px-0 flex-1 overflow-hidden pb-3">
+      <div className="hidden md:flex min-w-0 min-h-0 px-0 flex-1 overflow-hidden pb-3">
         <AnimatePresence initial={false}>
           {state.showSidebarLeft && (
             <motion.div
@@ -390,14 +390,14 @@ function ManageLayoutContent({
         </AnimatePresence>
         <div
           className={clsx(
-            'bg-(--btn-tertiary) transition-all ease-in-out duration-500 w-full h-full rounded-none m-0 md:rounded-md md:m-1',
+            'bg-(--btn-tertiary) transition-all ease-in-out duration-500 min-w-0 w-full h-full rounded-none m-0 md:rounded-md md:m-1',
             state.device === 'mobile' && 'md:py-4',
           )}
         >
           <div
             data-mode={state.device}
             className={clsx(
-              'w-full bg-background h-full rounded-none md:rounded-md overflow-auto transition-all ease-in-out mx-auto duration-500',
+              'min-w-0 w-full bg-background h-full rounded-none md:rounded-md overflow-auto transition-all ease-in-out mx-auto duration-500',
               state.device === 'mobile' && 'md:w-sm',
             )}
           >

--- a/lib/components/features/community-manage/CommunityManageLayout.tsx
+++ b/lib/components/features/community-manage/CommunityManageLayout.tsx
@@ -35,28 +35,30 @@ type Props = React.PropsWithChildren<{
 
 function CommunityHeader({
   children,
+  embedded,
   pathname,
   space,
   uid,
 }: React.PropsWithChildren<{
+  embedded?: boolean;
   pathname: string | null;
   space: Space;
   uid: string;
 }>) {
   return (
     <>
-      <div className="px-4 md:px-0 pt-6 sticky top-0 bg-page-background backdrop-blur-3xl z-2 border-b">
-        <div className="page mx-auto">
-          <div className="flex justify-between items-center">
-            <div className="flex gap-3 items-center">
-              <img src={communityAvatar(space)} className="size-7 rounded-xs border-card-border" />
-              <h1 className="font-semibold text-2xl max-sm:line-clamp-1">{space.title}</h1>
+      <div className="pt-6 sticky top-0 bg-page-background backdrop-blur-3xl z-2 border-b">
+        <div className={clsx('page mx-auto min-w-0', embedded ? 'px-4 md:px-6' : 'px-4 md:px-0')}>
+          <div className="flex justify-between items-center gap-3 min-w-0">
+            <div className="flex gap-3 items-center min-w-0">
+              <img src={communityAvatar(space)} className="size-7 shrink-0 rounded-xs border-card-border" />
+              <h1 className="font-semibold text-2xl truncate">{space.title}</h1>
             </div>
             <Button
               iconRight="icon-arrow-outward"
               variant="tertiary-alt"
               size="sm"
-              className="hidden md:block"
+              className="hidden shrink-0 md:block"
               onClick={() => window.open(`/s/${uid}`, '_blank')}
             >
               Community Page
@@ -198,7 +200,7 @@ export function CommunityManageLayout({ children, embedded = false, onSpaceResol
 
   const content = (
     <CommunityManageSpaceProvider space={resolvedSpace} hostname={hostname}>
-      <CommunityHeader pathname={pathname} space={resolvedSpace} uid={uid}>
+      <CommunityHeader embedded={embedded} pathname={pathname} space={resolvedSpace} uid={uid}>
         {children}
       </CommunityHeader>
     </CommunityManageSpaceProvider>

--- a/lib/components/features/community-manage/CommunityOverview.tsx
+++ b/lib/components/features/community-manage/CommunityOverview.tsx
@@ -75,7 +75,7 @@ export function CommunityOverview({ space: initSpace, hostname }: { space?: Spac
   const events = (dataGetEvent?.getEvents || []) as Event[];
 
   return (
-    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
+    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-6">
       <div className="flex flex-col gap-8 pb-20">
         <div className="flex flex-col gap-8">
           <ListActions spaceId={space?._id} hostname={`https://${hostname}/s/${space.slug || space._id}`} />
@@ -132,11 +132,11 @@ const actions = [
 function ListActions({ spaceId, hostname }: { spaceId: string; hostname?: string }) {
   const router = useRouter();
   return (
-    <div className="flex gap-2 overflow-x-auto no-scrollbar">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
       {actions.map((item) => (
         <Card.Root
           key={item.key}
-          className="flex-1 min-w-fit"
+          className="min-w-0"
           onClick={() => {
             match(item.key)
               .with('add_event', () => router.push(`/create/event?space=${spaceId}`))
@@ -154,7 +154,7 @@ function ListActions({ spaceId, hostname }: { spaceId: string; hostname?: string
             >
               <i aria-hidden="true" className={twMerge('size-5.5 aspect-square', item.icon)} />
             </div>
-            <p>{item.title}</p>
+            <p className="truncate">{item.title}</p>
           </Card.Content>
         </Card.Root>
       ))}

--- a/lib/components/features/community-manage/shared.tsx
+++ b/lib/components/features/community-manage/shared.tsx
@@ -24,8 +24,8 @@ export function CommonSection({
 }) {
   return (
     <div className="space-y-5">
-      <div className="flex justify-between">
-        <div className="space-y-1 flex-1">
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-between">
+        <div className="space-y-1 flex-1 min-w-0">
           <div className="flex gap-2">
             <h3 className="text-xl font-semibold">{title}</h3>
             {count && (
@@ -38,7 +38,7 @@ export function CommonSection({
           <p className="text-secondary">{subtitle}</p>
         </div>
 
-        <div className="flex gap-2">
+        <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
           {actions.filter(Boolean).map((item, idx) => (
             <Button
               key={idx}
@@ -78,8 +78,8 @@ export function SmallCommonSection({
 }) {
   return (
     <div className="space-y-3">
-      <div className="flex justify-between">
-        <div className="space-y-1 flex-1">
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-between">
+        <div className="space-y-1 flex-1 min-w-0">
           <div className="flex gap-2">
             <p className="text-xl font-semibold">{title}</p>
             {count && (
@@ -91,18 +91,22 @@ export function SmallCommonSection({
 
           <p className="text-secondary">{subtitle}</p>
         </div>
-        {actions.map((item, idx) => (
-          <Button
-            key={idx}
-            iconLeft={item.iconLeft}
-            iconRight={item.iconRight}
-            size="sm"
-            variant="tertiary-alt"
-            onClick={item.onClick}
-          >
-            {item.title}
-          </Button>
-        ))}
+        {!!actions.length && (
+          <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+            {actions.map((item, idx) => (
+              <Button
+                key={idx}
+                iconLeft={item.iconLeft}
+                iconRight={item.iconRight}
+                size="sm"
+                variant="tertiary-alt"
+                onClick={item.onClick}
+              >
+                {item.title}
+              </Button>
+            ))}
+          </div>
+        )}
       </div>
       {children}
     </div>


### PR DESCRIPTION
## What
- Fixed community manage layout padding and alignment in embedded/smaller containers.
- Prevented manage preview content from overflowing horizontally.

## Why
- Content was getting cut off on smaller screens.
- The community manage header and body needed consistent left alignment.

## How
- Added responsive container padding and `min-w-0` constraints.
- Adjusted overview action cards and section headers to wrap cleanly.

## Designs
- UI fix based on reported screenshots.

## Test Steps
- [ ] Open community manage in desktop preview.
- [ ] Resize to smaller widths.
- [ ] Confirm content has side padding and stays aligned.
- [ ] Confirm right-side actions are reachable and not clipped.

## Other Notes
- No local diff is currently present, so this is based on the discussed fix scope.
