### PR TITLE
fix(lens): restrict wallet prompts to user actions

### DIFF
--- a/lib/components/features/lens-account/LensConnectWallet.tsx
+++ b/lib/components/features/lens-account/LensConnectWallet.tsx
@@ -1,31 +1,19 @@
 'use client';
-import { useState, useEffect } from 'react';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 
 import { Button, Menu, MenuItem } from '$lib/components/core';
-import { useConnectWallet } from '$lib/hooks/useConnectWallet';
-import { chainsMapAtom, sessionClientAtom } from '$lib/jotai';
-import { LENS_CHAIN_ID } from '$lib/utils/lens/constants';
+import { useLensWalletConnection } from '$lib/hooks/useLens';
+import { sessionClientAtom } from '$lib/jotai';
 import { useDisconnect } from '$lib/utils/appkit';
 import { useMediaQuery } from '$lib/hooks/useMediaQuery';
 import { useClient } from '$lib/graphql/request';
 
 export function LensConnectWallet({ onConnect }: { onConnect: () => void }) {
-  const chainsMap = useAtomValue(chainsMapAtom);
-  const { connect, isReady } = useConnectWallet(chainsMap[LENS_CHAIN_ID]);
+  const { connect, isReady } = useLensWalletConnection();
   const { disconnect } = useDisconnect();
   const setSessionClient = useSetAtom(sessionClientAtom);
   const isDesktop = useMediaQuery('md');
   const { client } = useClient();
-
-  const [wasClicked, setWasClicked] = useState(false);
-
-  useEffect(() => {
-    if (wasClicked && isReady) {
-      onConnect();
-      setWasClicked(false);
-    }
-  }, [isReady, wasClicked]);
 
   if (isReady && isDesktop) {
     return (
@@ -127,10 +115,7 @@ export function LensConnectWallet({ onConnect }: { onConnect: () => void }) {
         variant="secondary"
         size={isDesktop ? 'base' : 'sm'}
         className="w-fit md:w-full"
-        onClick={() => {
-          setWasClicked(true);
-          connect();
-        }}
+        onClick={() => connect({ userInitiated: true, onConnect })}
       >
         Connect Wallet
       </Button>

--- a/lib/components/features/lens-account/LensProfileCard.tsx
+++ b/lib/components/features/lens-account/LensProfileCard.tsx
@@ -110,7 +110,7 @@ export function LensProfileCard({ account }: { account: Account }) {
             variant={isFollowing ? 'tertiary' : 'secondary'}
             className="w-full"
             size="sm"
-            onClick={() => handleLensAuth(handleFollow)}
+            onClick={() => handleLensAuth(handleFollow, { userInitiated: true })}
             loading={isExecuting}
             disabled={isLoadingStatus}
           >

--- a/lib/components/features/lens-account/WhoToFollow.tsx
+++ b/lib/components/features/lens-account/WhoToFollow.tsx
@@ -161,7 +161,7 @@ export function WhoToFollow() {
             variant="tertiary"
             size="sm"
             className="rounded-full"
-            onClick={() => handleLensAuth(() => handleFollow(account))}
+            onClick={() => handleLensAuth(() => handleFollow(account), { userInitiated: true })}
             loading={followLoading === account.address}
             disabled={followLoading === account.address}
           >

--- a/lib/components/features/lens-feed/PostComment.tsx
+++ b/lib/components/features/lens-feed/PostComment.tsx
@@ -34,7 +34,7 @@ export function PostComment({ post }: PostCommentProps) {
       label={commentCount}
       onClick={(e) => {
         e.stopPropagation();
-        handleLensAuth(handleAddComment);
+        handleLensAuth(handleAddComment, { userInitiated: true });
       }}
     />
   );

--- a/lib/components/features/lens-feed/PostReaction.tsx
+++ b/lib/components/features/lens-feed/PostReaction.tsx
@@ -80,7 +80,7 @@ export function PostReaction({ post, isComment }: PostReactionProps) {
       icon={isUpvoted ? 'icon-heart-filled' : 'icon-heart-outline'}
       onClick={(e) => {
         e.stopPropagation();
-        handleLensAuth(handleUpvote);
+        handleLensAuth(handleUpvote, { userInitiated: true });
       }}
       label={upvotes}
       isActive={isUpvoted}

--- a/lib/components/features/user-profile/UserProfileHero.tsx
+++ b/lib/components/features/user-profile/UserProfileHero.tsx
@@ -140,7 +140,12 @@ export function UserProfileHero({ address, user, canEdit, containerClass }: Prop
             .otherwise(() => (
               <div className="flex items-center gap-2">
                 {user?._id !== me?._id && (
-                  <Button loading={loading} size="sm" outlined={followed} onClick={() => handleLensAuth(handleFollow)}>
+                  <Button
+                    loading={loading}
+                    size="sm"
+                    outlined={followed}
+                    onClick={() => handleLensAuth(handleFollow, { userInitiated: true })}
+                  >
                     {followed ? 'Unfollow' : 'Follow'}
                   </Button>
                 )}

--- a/lib/hooks/useLens.ts
+++ b/lib/hooks/useLens.ts
@@ -20,7 +20,7 @@ import {
 import { AccountMetadata, account, MetadataAttributeType } from '@lens-protocol/metadata';
 import { setAccountMetadata } from '@lens-protocol/client/actions';
 import { useAtomValue, useSetAtom, useAtom } from 'jotai';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { delay } from 'lodash';
 
 import {
@@ -37,7 +37,7 @@ import {
 import { fetchAccount } from '@lens-protocol/client/actions';
 import { toast } from '$lib/components/core/toast';
 import { sessionClientAtom, accountAtom, feedAtom, feedPostsAtom, chainsMapAtom, feedPostAtom, lemonadeUsernameAtom } from '$lib/jotai';
-import { useAppKitAccount } from '$lib/utils/appkit';
+import { useAppKitAccount, useAppKitNetwork } from '$lib/utils/appkit';
 import { client, storageClient } from '$lib/utils/lens/client';
 import { LENS_CHAIN_ID } from '$lib/utils/lens/constants';
 import { modal } from '$lib/components/core';
@@ -45,7 +45,6 @@ import { SelectProfileModal } from '$lib/components/features/lens-account/Select
 import { useClient } from '$lib/graphql/request';
 
 import { useSigner } from './useSigner';
-import { useConnectWallet } from './useConnectWallet';
 import { useMe } from './useMe';
 import { UpdateUserDocument, UpdateUserMutationVariables, User } from '$lib/graphql/generated/backend/graphql';
 import { uploadFiles } from '$lib/utils/file';
@@ -309,7 +308,7 @@ type PostFilter = {
 export function useFeedPosts(postFilter: PostFilter) {
   const sessionClient = useAtomValue(sessionClientAtom);
   // const [posts, setPosts] = useAtom(feedPostsAtom);
-  const [posts, setPosts] = React.useState([]);
+  const [posts, setPosts] = React.useState<AnyPost[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<string | undefined>();
@@ -680,31 +679,85 @@ export function useAccountStats(account: Account | null) {
   };
 }
 
+type LensAuthOptions = {
+  userInitiated?: boolean;
+};
+
+type LensWalletConnectionOptions = {
+  userInitiated?: boolean;
+  onConnect?: () => void;
+};
+
+export function useLensWalletConnection() {
+  const chainsMap = useAtomValue(chainsMapAtom);
+  const lensChain = chainsMap[LENS_CHAIN_ID];
+  const { isConnected } = useAppKitAccount();
+  const { chainId } = useAppKitNetwork();
+
+  const isReady = useMemo(() => {
+    if (!isConnected) return false;
+    if (!lensChain) return true;
+    return chainId?.toString() === lensChain.chain_id;
+  }, [isConnected, chainId, lensChain]);
+
+  const connect = useCallback(({ userInitiated, onConnect }: LensWalletConnectionOptions = {}) => {
+    if (!userInitiated) return;
+
+    if (isReady) {
+      onConnect?.();
+      return;
+    }
+
+    modal.open(ConnectWallet, {
+      dismissible: true,
+      props: {
+        chain: lensChain,
+        onConnect: () => {
+          onConnect?.();
+        },
+      },
+    });
+  }, [isReady, lensChain]);
+
+  return { isReady, connect };
+}
+
 export function useLensAuth() {
   const account = useAtomValue(accountAtom);
   const sessionClient = useAtomValue(sessionClientAtom);
-  const chainsMap = useAtomValue(chainsMapAtom);
-  const { isReady, connect } = useConnectWallet(chainsMap[LENS_CHAIN_ID]);
+  const { isReady, connect } = useLensWalletConnection();
   const { logIn } = useLogIn();
 
-  const handleAuth = async (action: () => Promise<void>): Promise<void> => {
+  const handleAuth = async (action: () => Promise<void>, options: LensAuthOptions = {}): Promise<void> => {
+    const shouldPrompt = options.userInitiated === true;
+
     if (account) {
       await action();
       return;
     }
 
     if (sessionClient) {
+      if (!shouldPrompt) return;
+
       modal.open(SelectProfileModal);
       return;
     }
 
     if (isReady) {
+      if (!shouldPrompt) return;
+
       toast.error('Please login to your Lens account to continue');
       await logIn();
       return;
     }
 
-    connect();
+    connect({
+      userInitiated: shouldPrompt,
+      onConnect: () => {
+        toast.error('Please login to your Lens account to continue');
+        void logIn();
+      },
+    });
   };
 
   return handleAuth;


### PR DESCRIPTION
## What
- Restricted Lens wallet prompts to explicit user actions.
- Added a Lens-specific wallet connection path.
- Updated Lens follow, comment, reaction, and profile connect actions.

## Why
- Prevents browser wallet/AppKit prompts from appearing automatically in Lens flows.
- Keeps non-Lens wallet behavior untouched.

## How
- Added user-initiated guards in Lens auth/connect logic.
- Routed Lens connect UI through the app `ConnectWallet` modal with the Lens chain.
- Removed the `wasClicked` state/effect pattern.

## Designs
- N/A

## Test Steps
- [ ] Open a Lens-enabled page.
- [ ] Confirm wallet modal does not appear automatically.
- [ ] Click Lens connect/follow/comment/reaction.
- [ ] Confirm the app wallet modal opens before wallet connection.

## Other Notes
- Skipped full `tsc --noEmit` due known timeout.
