### PR TITLE
fix: community manage page padding alignment

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -578,6 +578,16 @@ main {
   width: 100%;
 }
 
+.community-manage-page-padding {
+  padding-inline: 1rem;
+}
+
+@media (min-width: 768px) {
+  .community-manage-page-padding {
+    padding-inline: var(--community-manage-page-padding, 0px);
+  }
+}
+
 .page:has([data-coin-template='true']) {
   max-width: 75rem;
   width: 100%;

--- a/lib/components/features/community-manage/CommunityAgents.tsx
+++ b/lib/components/features/community-manage/CommunityAgents.tsx
@@ -141,7 +141,7 @@ export function CommunityAgents({ space }: Props) {
   }, [configsById, handleRefetch, scope]);
 
   return (
-    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
+    <div className="page bg-transparent! mx-auto py-7 community-manage-page-padding">
       <div className="flex flex-col gap-5">
         <div className="flex gap-2 items-center justify-between">
           <div className="flex flex-col gap-1 flex-1">

--- a/lib/components/features/community-manage/CommunityEvents.tsx
+++ b/lib/components/features/community-manage/CommunityEvents.tsx
@@ -12,7 +12,7 @@ export function CommunityEvents({ space: initSpace }: { space: Space }) {
   const space = data?.getSpace as Space;
 
   return (
-    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
+    <div className="page bg-transparent! mx-auto py-7 community-manage-page-padding">
       <CommunityEventsWithCalendar space={space} className="[&_.event-calendar]:top-36" />
     </div>
   );

--- a/lib/components/features/community-manage/CommunityInsightsOverview.tsx
+++ b/lib/components/features/community-manage/CommunityInsightsOverview.tsx
@@ -104,7 +104,7 @@ export function CommunityInsightsOverview({ space }: { space: Space }) {
   const topCountries = countriesData?.getSpaceEventLocationsLeaderboard ?? [];
 
   return (
-    <div className="page mx-auto py-7 px-4 md:px-0">
+    <div className="page mx-auto py-7 community-manage-page-padding">
       <div className="flex flex-col gap-8 pb-20">
         <section className="space-y-4">
           <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">

--- a/lib/components/features/community-manage/CommunityLaunchpad.tsx
+++ b/lib/components/features/community-manage/CommunityLaunchpad.tsx
@@ -32,7 +32,7 @@ export function CommunityLaunchpad() {
   }, [tokenIds]);
 
   return (
-    <div className="page mx-auto py-7 px-4 md:px-0 flex flex-col gap-8">
+    <div className="page mx-auto py-7 community-manage-page-padding flex flex-col gap-8">
       {
         launchpadGroup ? (
           <CoinStats launchpadGroup={launchpadGroup as LaunchpadGroup} />

--- a/lib/components/features/community-manage/CommunityManageLayout.tsx
+++ b/lib/components/features/community-manage/CommunityManageLayout.tsx
@@ -35,12 +35,10 @@ type Props = React.PropsWithChildren<{
 
 function CommunityHeader({
   children,
-  embedded,
   pathname,
   space,
   uid,
 }: React.PropsWithChildren<{
-  embedded?: boolean;
   pathname: string | null;
   space: Space;
   uid: string;
@@ -48,7 +46,7 @@ function CommunityHeader({
   return (
     <>
       <div className="pt-6 sticky top-0 bg-page-background backdrop-blur-3xl z-2 border-b">
-        <div className={clsx('page mx-auto min-w-0', embedded ? 'px-4 md:px-6' : 'px-4 md:px-0')}>
+        <div className="page mx-auto min-w-0 community-manage-page-padding">
           <div className="flex justify-between items-center gap-3 min-w-0">
             <div className="flex gap-3 items-center min-w-0">
               <img src={communityAvatar(space)} className="size-7 shrink-0 rounded-xs border-card-border" />
@@ -200,14 +198,14 @@ export function CommunityManageLayout({ children, embedded = false, onSpaceResol
 
   const content = (
     <CommunityManageSpaceProvider space={resolvedSpace} hostname={hostname}>
-      <CommunityHeader embedded={embedded} pathname={pathname} space={resolvedSpace} uid={uid}>
+      <CommunityHeader pathname={pathname} space={resolvedSpace} uid={uid}>
         {children}
       </CommunityHeader>
     </CommunityManageSpaceProvider>
   );
 
   if (embedded) {
-    return <div className="flex flex-col h-full overflow-auto">{content}</div>;
+    return <div className="flex flex-col h-full overflow-auto [--community-manage-page-padding:1.5rem]">{content}</div>;
   }
 
   return (

--- a/lib/components/features/community-manage/CommunityManagePreview.tsx
+++ b/lib/components/features/community-manage/CommunityManagePreview.tsx
@@ -36,7 +36,7 @@ export default function CommunityManagePreview({
       <ThemeGenerator data={themeData} scoped scopeSelector="[data-theme-scope='community-preview']" />
       <ThemeProvider key={providerKey} themeData={themeData}>
         <div className="relative z-10 flex w-full flex-1">
-          <div className="page mx-auto w-full px-4 pt-6 pb-20 xl:px-0">
+          <div className="page mx-auto w-full px-4 pt-6 pb-20 md:px-6">
             <Community initData={{ space }} hideManageControls />
           </div>
         </div>

--- a/lib/components/features/community-manage/CommunityNewsletter.tsx
+++ b/lib/components/features/community-manage/CommunityNewsletter.tsx
@@ -213,7 +213,7 @@ export function CommunityNewsletter({ spaceIdOrSlug }: CommunityNewsletterProps)
   const actionMenuDisabled = duplicatingNewsletter || deletingNewsletter;
 
   return (
-    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
+    <div className="page bg-transparent! mx-auto py-7 community-manage-page-padding">
       <div className="flex flex-col gap-8 pb-20">
         <section className="flex flex-col gap-5">
           <div className="space-y-1">

--- a/lib/components/features/community-manage/CommunityPayments.tsx
+++ b/lib/components/features/community-manage/CommunityPayments.tsx
@@ -15,7 +15,7 @@ export function CommunityPayments({ space }: { space: Space }) {
   const items = (data?.listSpacePaymentAccounts?.items ?? []) as NewPaymentAccount[];
 
   return (
-    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0 space-y-8">
+    <div className="page bg-transparent! mx-auto py-7 community-manage-page-padding space-y-8">
       <CommunityVaultsSection space={space} items={items} loading={loading} refetch={refetch} />
       <hr className="border-t" />
       <CommunityStripeSection space={space} items={items} loading={loading} refetch={refetch} />

--- a/lib/components/features/community-manage/CommunityPeople.tsx
+++ b/lib/components/features/community-manage/CommunityPeople.tsx
@@ -110,7 +110,7 @@ export function CommunityPeople({ space }: Props) {
   }, [query]);
 
   return (
-    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
+    <div className="page bg-transparent! mx-auto py-7 community-manage-page-padding">
       <div className="flex flex-col gap-3">
         <div className="flex gap-2 items-center">
           <h3 className="flex-1 text-xl font-semibold">

--- a/lib/components/features/community-manage/CommunitySubmissions.tsx
+++ b/lib/components/features/community-manage/CommunitySubmissions.tsx
@@ -91,7 +91,7 @@ export function CommunitySubmissions({ space }: Props) {
   };
 
   return (
-    <div className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
+    <div className="page bg-transparent! mx-auto py-7 community-manage-page-padding">
       <div className="flex flex-col gap-4">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <h3 className="text-xl font-semibold">

--- a/lib/components/features/community-manage/modals/EditApiKeyModal.tsx
+++ b/lib/components/features/community-manage/modals/EditApiKeyModal.tsx
@@ -9,7 +9,7 @@ import { useMutation } from '$lib/graphql/request';
 import { getErrorMessage } from '$lib/utils/error';
 
 type EditApiKeyModalProps = {
-  apiKey: ApiKeyBase;
+  apiKey: Pick<ApiKeyBase, '_id' | 'name' | 'scopes' | 'key_prefix' | 'expires_at'>;
   availableScopes: string[];
   onUpdated?: () => void | Promise<void>;
 };

--- a/lib/components/features/community-manage/modals/RegenerateApiKeyModal.tsx
+++ b/lib/components/features/community-manage/modals/RegenerateApiKeyModal.tsx
@@ -7,7 +7,7 @@ import { getErrorMessage } from '$lib/utils/error';
 import { copy } from '$lib/utils/helpers';
 
 type RegenerateApiKeyModalProps = {
-  apiKey: ApiKeyBase;
+  apiKey: Pick<ApiKeyBase, '_id' | 'name'>;
   onRegenerated?: () => void | Promise<void>;
 };
 

--- a/lib/components/features/community-manage/settings/SettingsCommunityAvanced.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityAvanced.tsx
@@ -49,7 +49,7 @@ export function SettingsCommunityAvanced(props: { space: Space }) {
   };
 
   return (
-    <div className="page mx-auto py-7 px-4 md:px-0 flex flex-col gap-8">
+    <div className="page mx-auto py-7 community-manage-page-padding flex flex-col gap-8">
       <div className="flex flex-col gap-5">
         <div>
           <h3 className="text-xl font-semibold flex-1">Event Defaults</h3>

--- a/lib/components/features/community-manage/settings/SettingsCommunityDeveloper.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityDeveloper.tsx
@@ -20,6 +20,8 @@ import { EditApiKeyModal } from '../modals/EditApiKeyModal';
 import { RegenerateApiKeyModal } from '../modals/RegenerateApiKeyModal';
 import { ConfirmModal } from '../../modals/ConfirmModal';
 
+type ApiKeyListItem = Pick<ApiKeyBase, '_id' | 'name'>;
+
 export function SettingsCommunityDeveloper({ space }: { space: Space }) {
   const [openMenuId, setOpenMenuId] = React.useState<string | null>(null);
   const uid = space.slug || space._id;
@@ -67,7 +69,7 @@ export function SettingsCommunityDeveloper({ space }: { space: Space }) {
 
   const formatStatusLabel = (status: string) => `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
 
-  const openDeleteConfirmation = (apiKey: ApiKeyBase) => {
+  const openDeleteConfirmation = (apiKey: ApiKeyListItem) => {
     modal.open(ConfirmModal, {
       props: {
         title: 'Delete Key?',
@@ -84,7 +86,7 @@ export function SettingsCommunityDeveloper({ space }: { space: Space }) {
   };
 
   return (
-    <div className="page mx-auto py-7 px-4 md:px-0 flex flex-col gap-6">
+    <div className="page mx-auto py-7 community-manage-page-padding flex flex-col gap-6">
       <section className="flex flex-col gap-5">
         <div className="space-y-1">
           <h3 className="text-xl font-semibold">API Keys</h3>

--- a/lib/components/features/community-manage/settings/SettingsCommunityDisplay.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityDisplay.tsx
@@ -269,8 +269,8 @@ export function CommunityDetailForm({ space }: { space: Space }) {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       {isDirty && (
-        <div data-submit-content className="px-4 md:px-0 bg-warning-300/16 backdrop-blur-sm sticky top-39 z-50">
-          <div className="page mx-auto flex justify-between py-3 items-center">
+        <div data-submit-content className="bg-warning-300/16 backdrop-blur-sm sticky top-39 z-50">
+          <div className="page mx-auto community-manage-page-padding flex justify-between py-3 items-center">
             <p className="text-warning-300">You have unsaved changes.</p>
             <Button type="submit" size="sm" loading={isSubmitting} className="rounded-full" variant="warning">
               Save Changes
@@ -279,7 +279,7 @@ export function CommunityDetailForm({ space }: { space: Space }) {
         </div>
       )}
 
-      <div data-form-content className="page bg-transparent! mx-auto py-7 px-4 md:px-0">
+      <div data-form-content className="page bg-transparent! mx-auto py-7 community-manage-page-padding">
         <div className="flex flex-col gap-4">
           <Card.Root>
             <Card.Content className="p-0">

--- a/lib/components/features/community-manage/settings/SettingsCommunityEmbed.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityEmbed.tsx
@@ -27,7 +27,7 @@ export function SettingsCommunityEmbed({ space }: { space: Space }) {
   }, []);
 
   return (
-    <div className="page mx-auto py-7 px-4 md:px-0 flex flex-col gap-8">
+    <div className="page mx-auto py-7 community-manage-page-padding flex flex-col gap-8">
       <div className="flex flex-col gap-4">
         <div>
           <div className="flex justify-between items-center">

--- a/lib/components/features/community-manage/settings/SettingsCommunityLayout.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityLayout.tsx
@@ -23,7 +23,7 @@ function SettingsCommunityLayout({ children }: React.PropsWithChildren) {
   return (
     <>
       <div className="bg-card sticky top-28 z-2 backdrop-blur-sm">
-        <nav className="page flex gap-4 px-4 md:px-0 pt-2 mx-auto overflow-auto no-scrollbar">
+        <nav className="page flex gap-4 community-manage-page-padding pt-2 mx-auto overflow-auto no-scrollbar">
           {tabs.map((item) => {
             const url =
               item.path === 'display' ? `/s/manage/${uid}/settings` : `/s/manage/${uid}/settings/${item.path}`;

--- a/lib/components/features/community-manage/settings/SettingsCommunityTags.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityTags.tsx
@@ -35,7 +35,7 @@ export function SettingsCommunityTags({ space }: { space: Space }) {
   };
 
   return (
-    <div className="page mx-auto py-7 px-4 md:px-0 flex flex-col gap-8">
+    <div className="page mx-auto py-7 community-manage-page-padding flex flex-col gap-8">
       <div className="flex flex-col gap-4">
         <div>
           <div className="flex justify-between items-center">

--- a/lib/components/features/community-manage/settings/SettingsCommunityTeam.tsx
+++ b/lib/components/features/community-manage/settings/SettingsCommunityTeam.tsx
@@ -11,6 +11,7 @@ import {
 } from '$lib/graphql/generated/backend/graphql';
 import { useMutation, useQuery } from '$lib/graphql/request';
 import { useMe } from '$lib/hooks/useMe';
+import { getErrorMessage } from '$lib/utils/error';
 import { userAvatar } from '$lib/utils/user';
 import React from 'react';
 import { ConfirmModal } from '../../modals/ConfirmModal';
@@ -18,7 +19,7 @@ import { AddTeam } from '../modals/AddTeam';
 
 export function SettingsCommunityTeam({ space }: { space: Space }) {
   return (
-    <div className="page mx-auto py-7 px-4 md:px-0 flex flex-col gap-8">
+    <div className="page mx-auto py-7 community-manage-page-padding flex flex-col gap-8">
       <AdminSection space={space} />
       <Divider />
       <AmbassadorSection space={space} />
@@ -50,7 +51,7 @@ export function AdminSection({ space }: { space: Space }) {
   const handleRemove = async (id: string) => {
     const { error } = await removeMember({ variables: { input: { space: space._id, ids: [id] } } });
     if (error) {
-      toast.error(error.message);
+      toast.error(getErrorMessage(error));
       return;
     }
     await refetch();
@@ -179,7 +180,7 @@ export function AmbassadorSection({ space }: { space: Space }) {
   const handleRemove = async (id: string) => {
     const { error } = await removeMember({ variables: { input: { space: space._id, ids: [id] } } });
     if (error) {
-      toast.error(error.message);
+      toast.error(getErrorMessage(error));
       return;
     }
     await refetch();

--- a/lib/utils/user.ts
+++ b/lib/utils/user.ts
@@ -2,19 +2,22 @@ import { createAvatar } from '@dicebear/core';
 import * as identicon from '@dicebear/identicon';
 import * as thumbs from '@dicebear/thumbs';
 
-import { File, User } from "$lib/graphql/generated/backend/graphql";
+import { File } from "$lib/graphql/generated/backend/graphql";
 
 import { EDIT_KEY, generateUrl } from "./cnd";
+
+type UserAvatarFile = Pick<File, 'bucket' | 'key'> & Partial<Pick<File, 'type' | 'url'>>;
 
 type UserAvatarInput = {
   _id?: string | null;
   image_avatar?: string | null;
-  new_photos_expanded?: Array<Pick<File, 'bucket' | 'key' | 'type' | 'url'> | null> | null;
+  new_photos_expanded?: Array<UserAvatarFile | null> | null;
 };
 
 export function userAvatar(user?: UserAvatarInput | null, edits: keyof typeof EDIT_KEY = 'PROFILE') {
-  if (user && user.new_photos_expanded?.[0]) {
-    return generateUrl(user.new_photos_expanded[0], edits) || '';
+  const photo = user?.new_photos_expanded?.[0];
+  if (photo) {
+    return generateUrl({ ...photo, type: photo.type || '', url: photo.url || '' }, edits) || '';
   }
 
   if (user && user.image_avatar) {


### PR DESCRIPTION
## What
- Added shared `community-manage-page-padding` styling for community manage pages.
- Applied consistent padding to community manage header, tabs, settings pages, and main content views.
- Kept horizontal padding in community Design and Preview mode on desktop.
- Adjusted API key modal prop types to match the fields returned by the list query.
- Updated `userAvatar` to accept partial photo data from member queries.
- Replaced unsafe mutation error access with `getErrorMessage`.

## Why
- Align navbar, settings tabs, and content to the same padded grid.
- Prevent Design and Preview community content from sitting flush against the canvas edge.
- Resolve TypeScript errors caused by generated GraphQL operation types being narrower than schema types.

## How
- Introduced a reusable CSS padding utility with an embedded-shell override.
- Replaced duplicated `px-4 md:px-0` manage-page classes with the shared utility.
- Changed preview padding from `xl:px-0` to desktop padding.
- Narrowed modal prop contracts with `Pick<ApiKeyBase, ...>`.
- Normalized optional avatar file fields before calling `generateUrl`.

## Designs
- UI screenshots were provided in the task thread for navbar/content alignment and Design/Preview padding.

## Test Steps
- [ ] Open a community manage page.
- [ ] Confirm the top navbar, settings tabs, and content cards align to the same left padding.
- [ ] Switch to Design mode.
- [ ] Confirm preview content has horizontal padding on desktop.
- [ ] Switch to Preview mode.
- [ ] Confirm preview content keeps the same padded inset.
- [ ] Run the targeted TypeScript check for affected files.
- [ ] Run `git diff --check`.

## Other Notes
- Targeted `oxlint` reported 0 errors, with existing accessibility warnings still present in `CommunityPeople` and `SettingsCommunityTeam`.
- Description is based on HEAD commit `427fa439`; the working tree is currently clean.
